### PR TITLE
Schema thoughts / Basic DB Design

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,52 @@
+# Notify Schema
+
+Please look at the code to confirm schema as this might not be fully up to date.
+It should provide an overview of the concepts though...
+
+Conceptually, I'm thinking that notification groups could be created linking members from a query (e.g. all mSupply users with permission to a particular store)
+We might implement it different ways, e.g. with an SQL query in the group itself, or maybe there's a process that refreshes the group members from a query on a schedule?
+For MVP, we'll create of groups and members manually.
+
+```mermaid
+erDiagram
+    NOTIFICATION_EVENT {
+        TEXT id PK "UNIQUE NOT NULL"
+        TEXT notification_group_id FK "NOT NULL"
+        TEXT notification_type "NOT NULL (TELEGRAM/EMAIL/ETC)"
+        TEXT to_address "NOT NULL (Email address/Chat_id/ETC)"
+        TEXT status "NOT NULL"
+        TIMESTAMP created_at "NOT NULL"
+        TIMESTAMP updated_at "NOT NULL"
+        TIMESTAMP send_at "NULLABLE"
+        INTEGER retries "DEFAULT 0"
+        TEXT message_content "NOT NULL (JSON?)"
+        TEXT error_message "NULLABLE"
+    }
+    NOTIFICATION_GROUP {
+        TEXT id PK "UNIQUE NOT NULL"
+        TEXT name "NOT NULL"
+        TEXT description "NOT NULL"
+    }
+    NOTIFICATION_GROUP_MEMBER {
+        TEXT id PK "UNIQUE NOT NULL"
+        TEXT notification_group_id FK "NOT NULL"
+        TEXT notification_type "NOT NULL (TELEGRAM/EMAIL/ETC)"
+        TEXT to_address "NOT NULL (Email address/Chat_id/ETC)"
+    }
+    USER {
+	    TEXT id PK "UNIQUE NOT NULL"
+	    TEXT display_name "NOT NULL"
+        TEXT username  "NOT NULL"
+        TEXT hashed_password "NOT NULL (bcrypt)"
+        TEXT email "NOT NULL"
+    }
+    USER_PERMISSION {
+	    TEXT id PK "UNIQUE NOT NULL"
+        TEXT user_id FK "NOT NULL"
+        TEXT organisation_id FK ""
+	    TEXT permission "NOT NULL"
+    }
+    NOTIFICATION_GROUP ||--o{ NOTIFICATION_EVENT : has
+    NOTIFICATION_GROUP ||--o{ NOTIFICATION_GROUP_MEMBER : has
+    USER ||--o{ USER_PERMISSION : has
+```


### PR DESCRIPTION
Closes #3 

Essentially at this stage I'm thinking...
- we'll have users in the system as Admins only
- Notifications will be setup using notification groups containing either telegram or email users
- (Future design work needed for sourcing notification groups or members from db or something)
- The goal for the notification_event table is to be able to provide an Admin UI to view and debug notifications  (We might still have a separate `email_queue` table for example)