### PR TITLE
Configure ports

### DIFF
--- a/backend/configuration/base.yaml
+++ b/backend/configuration/base.yaml
@@ -1,5 +1,5 @@
 server:
-  port: 8176
+  port: 8007
   debug_cors_permissive: true # enable this to allow any origin for development purposes
   cors_origins: [http://localhost:3007] # Used to set the allowed origins in Cross Origin Request Security
   app_url: "http://localhost:3007"

--- a/frontend/codegen.yml
+++ b/frontend/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: 'http://127.0.0.1:8001/graphql'
+schema: 'http://127.0.0.1:8007/graphql'
 generates:
   ./packages/common/src/types/schema.ts:
     plugins:

--- a/frontend/packages/config/src/config.ts
+++ b/frontend/packages/config/src/config.ts
@@ -5,13 +5,13 @@ declare const APP_BUILD_VERSION: string;
 // i.e. web app is on https://my.healthsupplyhub.com/, then graphql will be available https://my.openmsupply.com/graphql
 
 // For development, API server and front end are launched seperately on different ports and possible different IPs
-// by default we assume development API server is launched on the same domain/ip and on port 8001 (Default). We can overwrite this
+// by default we assume development API server is launched on the same domain/ip and on port 8007 (Default). We can overwrite this
 // with API_HOST which is available through webpack.DefinePlugin (i.e. webpack server --env API_HOST='localhost:9000')
 
 const isProductionBuild = process.env['NODE_ENV'] === 'production';
 const { port, hostname, protocol } = window.location;
 
-const defaultDevelopmentApiHost = `${protocol}//${hostname}:8001`;
+const defaultDevelopmentApiHost = `${protocol}//${hostname}:8007`;
 const productionApiHost = `${protocol}//${hostname}:${port}`;
 
 const developmentApiHost =

--- a/frontend/packages/config/src/index.ts
+++ b/frontend/packages/config/src/index.ts
@@ -16,7 +16,7 @@ declare global {
   }
 }
 
-const { API_HOST = 'http://localhost:8001', BUILD_VERSION = '0.0.0' } =
+const { API_HOST = 'http://localhost:8007', BUILD_VERSION = '0.0.0' } =
   config ?? {};
 
 export const Environment: EnvironmentConfig = {

--- a/frontend/packages/host/package.json
+++ b/frontend/packages/host/package.json
@@ -27,7 +27,7 @@
     "start": "webpack-cli serve",
     "build": "webpack --env production --env APP_BUILD_VERSION=$APP_BUILD_VERSION",
     "build-stats": "webpack --env stats --env production",
-    "serve": "serve dist -p 3003",
+    "serve": "serve dist -p 3007",
     "tsc": "tsc"
   },
   "dependencies": {

--- a/frontend/packages/host/webpack.config.js
+++ b/frontend/packages/host/webpack.config.js
@@ -38,7 +38,7 @@ module.exports = env => {
         ? path.join(__dirname, 'dist')
         : path.join(__dirname, 'public'),
 
-      port: 3003,
+      port: 3007,
       historyApiFallback: true,
       headers: {
         'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION


# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Sets frontend port to 3007 and backend to 8007.

# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Startup the backend and frontend. Frontend should open on `localhost:3007`. Users page should render data from the backend. (Could also go to `localhost:8007/graphql` to see backend data there)

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

