### PR TITLE
Allow notify to run on a different URL

### DIFF
--- a/frontend/packages/common/src/intl/context/IntlContext.tsx
+++ b/frontend/packages/common/src/intl/context/IntlContext.tsx
@@ -39,7 +39,7 @@ export const IntlProvider: FC<PropsWithChildrenOnly> = ({ children }) => {
             },
             {
               /* options for secondary backend */
-              loadPath: '/locales/{{lng}}/{{ns}}.json',
+              loadPath: 'locales/{{lng}}/{{ns}}.json',
             },
           ],
         },

--- a/frontend/packages/config/src/config.ts
+++ b/frontend/packages/config/src/config.ts
@@ -1,6 +1,8 @@
 declare const API_HOST: string;
 declare const APP_BUILD_VERSION: string;
 declare const BUGSNAG_API_KEY: string;
+/* eslint-disable camelcase */
+declare const __webpack_public_path__: string;
 
 // For production, API is on the same domain/ip and port as web app, available through sub-route
 // i.e. web app is on https://my.healthsupplyhub.com/, then graphql will be available https://my.openmsupply.com/graphql
@@ -12,8 +14,20 @@ declare const BUGSNAG_API_KEY: string;
 const isProductionBuild = process.env['NODE_ENV'] === 'production';
 const { port, hostname, protocol } = window.location;
 
+// Extract the path webpack is serving the app from to use as the base path for react router
+// Default to `/` if not defined (e.g. when running in dev mode)
+let basePath = '/';
+try {
+  if (__webpack_public_path__ !== undefined) {
+    const url = new URL(__webpack_public_path__);
+    basePath = url.pathname;
+  }
+} catch (e) {
+  console.error(e);
+}
+
 const defaultDevelopmentApiHost = `${protocol}//${hostname}:8007`;
-const productionApiHost = `${protocol}//${hostname}:${port}`;
+const productionApiHost = `${protocol}//${hostname}:${port}${basePath}`;
 
 const developmentApiHost =
   (typeof API_HOST !== 'undefined' && API_HOST) || defaultDevelopmentApiHost;
@@ -24,10 +38,14 @@ const version =
   typeof APP_BUILD_VERSION !== 'undefined' && APP_BUILD_VERSION
     ? APP_BUILD_VERSION
     : '0.0.0';
-const bugsnagApiKey = typeof BUGSNAG_API_KEY !== 'undefined' && BUGSNAG_API_KEY ? BUGSNAG_API_KEY : '';
+const bugsnagApiKey =
+  typeof BUGSNAG_API_KEY !== 'undefined' && BUGSNAG_API_KEY
+    ? BUGSNAG_API_KEY
+    : '';
 
 export const Environment = {
   API_HOST: apiHost,
+  BASE_PATH: basePath,
   BUILD_VERSION: version,
   BUGSNAG_API_KEY: bugsnagApiKey,
 };

--- a/frontend/packages/config/src/index.ts
+++ b/frontend/packages/config/src/index.ts
@@ -5,6 +5,7 @@ interface EnvironmentConfig {
   API_HOST: string;
   BUILD_VERSION: string;
   BUGSNAG_API_KEY?: string;
+  BASE_PATH: string;
   FILE_URL: string;
   FILE_UPLOAD_URL: string;
   GRAPHQL_URL: string;
@@ -17,13 +18,18 @@ declare global {
   }
 }
 
-const { API_HOST = 'http://localhost:8007', BUILD_VERSION = '0.0.0', BUGSNAG_API_KEY = '' } =
-  config ?? {};
+const {
+  API_HOST = 'http://localhost:8007',
+  BUILD_VERSION = '0.0.0',
+  BUGSNAG_API_KEY = '',
+  BASE_PATH = '/',
+} = config ?? {};
 
 export const Environment: EnvironmentConfig = {
   API_HOST,
   BUILD_VERSION,
   BUGSNAG_API_KEY,
+  BASE_PATH,
   FILE_URL: `${API_HOST}/files?id=`,
   FILE_UPLOAD_URL: `${API_HOST}/files`,
   GRAPHQL_URL: `${API_HOST}/graphql`,

--- a/frontend/packages/host/src/Host.tsx
+++ b/frontend/packages/host/src/Host.tsx
@@ -68,7 +68,7 @@ const Host = () => (
                 <AppThemeProvider>
                   <ConfirmationModalProvider>
                     <AlertModalProvider>
-                      <BrowserRouter>
+                      <BrowserRouter basename={Environment.BASE_PATH}>
                         <AuthenticationAlert />
                         <Viewport>
                           <Box display="flex" minHeight="100%">

--- a/frontend/packages/host/webpack.config.js
+++ b/frontend/packages/host/webpack.config.js
@@ -10,7 +10,7 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 class DummyWebpackPlugin {
   apply(compiler) {
-    compiler.hooks.run.tap('DummyWebpackPlugin', () => { });
+    compiler.hooks.run.tap('DummyWebpackPlugin', () => {});
   }
 }
 
@@ -18,14 +18,14 @@ module.exports = env => {
   const isProduction = !!env.production;
   const bundleAnalyzerPlugin = !!env.stats
     ? new BundleAnalyzerPlugin({
-      /**
-       * In "server" mode analyzer will start HTTP server to show bundle report.
-       * In "static" mode single HTML file with bundle report will be generated.
-       * In "json" mode single JSON file with bundle report will be generated
-       */
-      analyzerMode: 'disabled',
-      generateStatsFile: true,
-    })
+        /**
+         * In "server" mode analyzer will start HTTP server to show bundle report.
+         * In "static" mode single HTML file with bundle report will be generated.
+         * In "json" mode single JSON file with bundle report will be generated
+         */
+        analyzerMode: 'disabled',
+        generateStatsFile: true,
+      })
     : new DummyWebpackPlugin();
 
   return {
@@ -54,7 +54,7 @@ module.exports = env => {
       plugins: [new TsconfigPathsPlugin()],
     },
     output: {
-      publicPath: '/',
+      publicPath: 'auto',
       path: path.resolve(__dirname, 'dist'),
       filename: '[name].[contenthash].js',
       chunkFilename: '[contenthash].js',
@@ -76,19 +76,19 @@ module.exports = env => {
           exclude: /node_modules/,
           options: isProduction
             ? {
-              /* ts-loader options */
-            }
+                /* ts-loader options */
+              }
             : {
-              /* swc-loader options */
-              jsc: {
-                parser: {
-                  dynamicImport: true,
-                  syntax: 'typescript',
-                  tsx: true,
+                /* swc-loader options */
+                jsc: {
+                  parser: {
+                    dynamicImport: true,
+                    syntax: 'typescript',
+                    tsx: true,
+                  },
+                  target: 'es2015',
                 },
-                target: 'es2015',
               },
-            },
         },
         {
           test: /\.css$/,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #232

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

This makes it possible to run notify on a path like https://yourserver.yourdomain.com/notify/

- [ ] Uses webpack `publicPath = 'auto'` mode See: https://webpack.js.org/guides/public-path/#automatic-publicpath
- [ ] Uses webpack's `__webpack_public_path__` to calculate the graphql path, and `ReactRouter` `basename`
- [ ] Uses relative path for translation file loading

# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

I've tried this with Caddy using a Caddy file like this.

```
:7007 {
	respond 404
	redir /notify /notify/
	handle_path /notify/* {
		reverse_proxy http://localhost:8007
	}
}
```

To serve the frontend via the backend server, you also need to run `yarn build`.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

Anything else I might have missed?
