### PR TITLE
Duplicate configs in the backend

### DIFF
--- a/backend/graphql/notification_config/src/mutations/duplicate.rs
+++ b/backend/graphql/notification_config/src/mutations/duplicate.rs
@@ -1,6 +1,6 @@
 use async_graphql::*;
 use graphql_core::{standard_graphql_error::validate_auth, ContextExt};
-use graphql_types::types::{ConfigKind, ConfigStatus, NotificationConfigNode};
+use graphql_types::types::NotificationConfigNode;
 use service::{
     auth::{Resource, ResourceAccessRequest},
     notification_config::duplicate::DuplicateNotificationConfig,
@@ -10,15 +10,8 @@ use super::{map_error, ModifyNotificationConfigResponse};
 
 #[derive(InputObject, Clone)]
 pub struct DuplicateNotificationConfigInput {
-    pub id: String,
-    pub title: String,
-    pub kind: ConfigKind,
-    pub status: ConfigStatus,
-    pub configuration_data: Option<String>,
-    pub parameters: Option<String>,
-    pub recipient_ids: Option<Vec<String>>,
-    pub recipient_list_ids: Option<Vec<String>>,
-    pub sql_recipient_list_ids: Option<Vec<String>>,
+    pub old_id: String,
+    pub new_id: String,
 }
 
 pub fn duplicate_notification_config(
@@ -48,28 +41,8 @@ pub fn duplicate_notification_config(
 
 impl From<DuplicateNotificationConfigInput> for DuplicateNotificationConfig {
     fn from(
-        DuplicateNotificationConfigInput {
-            id,
-            title,
-            kind,
-            status,
-            configuration_data,
-            parameters,
-            recipient_ids,
-            recipient_list_ids,
-            sql_recipient_list_ids,
-        }: DuplicateNotificationConfigInput,
+        DuplicateNotificationConfigInput { old_id, new_id }: DuplicateNotificationConfigInput,
     ) -> Self {
-        DuplicateNotificationConfig {
-            id,
-            title,
-            kind: ConfigKind::to_domain(kind),
-            status: ConfigStatus::to_domain(status),
-            configuration_data,
-            parameters,
-            recipient_ids,
-            recipient_list_ids,
-            sql_recipient_list_ids,
-        }
+        DuplicateNotificationConfig { old_id, new_id }
     }
 }

--- a/backend/service/src/notification_config/mod.rs
+++ b/backend/service/src/notification_config/mod.rs
@@ -9,23 +9,23 @@ use crate::{service_provider::ServiceContext, ListError, ListResult, SingleRecor
 use self::{
     create::{create_notification_config, CreateNotificationConfig},
     delete::{delete_notification_config, DeleteNotificationConfigError},
+    duplicate::{duplicate_notification_config, DuplicateNotificationConfig},
     query::{
-        find_all_due_by_kind, get_notification_config, get_notification_configs, NotificationConfig, get_notification_title,
+        find_all_due_by_kind, get_notification_config, get_notification_configs, NotificationConfig,
     },
     update::{update_notification_config, UpdateNotificationConfig},
-    duplicate::{duplicate_notification_config, DuplicateNotificationConfig},
 };
 
 mod tests;
 
 pub mod create;
 pub mod delete;
+pub mod duplicate;
 pub mod intervals;
 pub mod query;
 pub mod recipients;
 pub mod update;
 pub mod validate;
-pub mod duplicate;
 
 pub trait NotificationConfigServiceTrait: Sync + Send {
     fn find_all_due_by_kind(
@@ -85,14 +85,6 @@ pub trait NotificationConfigServiceTrait: Sync + Send {
         input: DuplicateNotificationConfig,
     ) -> Result<NotificationConfig, ModifyNotificationConfigError> {
         duplicate_notification_config(ctx, input)
-    }
-
-    fn get_notification_titles(
-        &self,
-        ctx: &ServiceContext,
-        title: String,
-        ) -> Result<ListResult<NotificationConfig>, ListError> {
-            get_notification_title(ctx, title)
     }
 }
 

--- a/backend/service/src/notification_config/query.rs
+++ b/backend/service/src/notification_config/query.rs
@@ -2,9 +2,9 @@ use chrono::NaiveDateTime;
 use repository::{
     EqualFilter, NotificationConfigFilter, NotificationConfigKind, NotificationConfigRepository,
     NotificationConfigRow, NotificationConfigRowRepository, NotificationConfigSort,
-    NotificationConfigStatus, PaginationOption, StringFilter,
+    NotificationConfigStatus, PaginationOption,
 };
-use util::{i64_to_u32, usize_to_u32};
+use util::i64_to_u32;
 
 use crate::{
     get_default_pagination, service_provider::ServiceContext, ListError, ListResult,
@@ -105,22 +105,3 @@ pub fn find_all_due_by_kind(
 
     Ok(result.into_iter().map(|row| row.into()).collect())
 }
-
-pub fn get_notification_title(
-    ctx: &ServiceContext,
-    title: String,
-) -> Result<ListResult<NotificationConfig>, ListError> {
-    let repository = NotificationConfigRepository::new(&ctx.connection);
-
-    let rows = repository
-    .query_by_filter(NotificationConfigFilter::new().title(StringFilter::equal_to(&title)))?;
-
-    let count = rows.len();
-
-    Ok(ListResult {
-        rows: rows.into_iter().map(|row| row.into()).collect(),
-        count: usize_to_u32(count),
-    })
-}
-
-

--- a/backend/service/src/notification_config/tests/duplicate.rs
+++ b/backend/service/src/notification_config/tests/duplicate.rs
@@ -1,0 +1,61 @@
+#[cfg(test)]
+mod notification_config_duplicate_tests {
+    use crate::notification_config::duplicate::DuplicateNotificationConfig;
+    use crate::service_provider::{ServiceContext, ServiceProvider};
+    use crate::test_utils::get_test_settings;
+    use repository::NotificationConfigStatus;
+    use repository::{
+        mock::{mock_coldchain_notification_config_a, MockDataInserts},
+        test_db::setup_all,
+    };
+    use std::sync::Arc;
+
+    #[actix_rt::test]
+    async fn notification_config_service_update_success() {
+        let (_, _, connection_manager, _) = setup_all(
+            "notification_config_service_update_success",
+            MockDataInserts::none().notification_configs(),
+        )
+        .await;
+
+        let service_provider = Arc::new(ServiceProvider::new(
+            connection_manager,
+            get_test_settings(""),
+        ));
+        let context = ServiceContext::as_server_admin(service_provider).unwrap();
+
+        // Duplicated mock_coldchain_notification_config_a() and check..
+
+        // New ID is correctly set in the database
+
+        let _duplicated_notification_config = context
+            .service_provider
+            .notification_config_service
+            .duplicate_notification_config(
+                &context,
+                DuplicateNotificationConfig {
+                    old_id: mock_coldchain_notification_config_a().id.clone(),
+                    new_id: "new_id".to_string(),
+                },
+            )
+            .unwrap();
+
+        // Get the duplicated notification config from the database (Check it's saved successfully)
+        let duplicated_notification_config = context
+            .service_provider
+            .notification_config_service
+            .get_notification_config(&context, "new_id".to_string())
+            .unwrap();
+
+        // Notification is set to disabled
+        assert_eq!(
+            duplicated_notification_config.status,
+            NotificationConfigStatus::Disabled
+        );
+
+        // Updated title is set based on the old title
+        assert!(duplicated_notification_config
+            .title
+            .contains(&mock_coldchain_notification_config_a().title));
+    }
+}

--- a/backend/service/src/notification_config/tests/mod.rs
+++ b/backend/service/src/notification_config/tests/mod.rs
@@ -9,3 +9,6 @@ mod update;
 
 #[cfg(test)]
 mod delete;
+
+#[cfg(test)]
+mod duplicate;

--- a/frontend/packages/common/src/intl/locales/en/system.json
+++ b/frontend/packages/common/src/intl/locales/en/system.json
@@ -98,5 +98,6 @@
   "label.degrees-celsius": "°C",
   "label.select-queries": "Select Queries",
   "message.no-queries-selected": "No queries selected",
-  "label.schedule": "Schedule"
+  "label.schedule": "Schedule",
+  "messages.confirm-duplicate": "Do you want to make a copy of this configuration?"
 }

--- a/frontend/packages/common/src/types/schema.ts
+++ b/frontend/packages/common/src/types/schema.ts
@@ -129,15 +129,8 @@ export type DeleteSqlRecipientListResponse = DeleteResponse;
 export type DeleteUserAccountResponse = DeleteResponse;
 
 export type DuplicateNotificationConfigInput = {
-  configurationData?: InputMaybe<Scalars['String']['input']>;
-  id: Scalars['String']['input'];
-  kind: ConfigKind;
-  parameters?: InputMaybe<Scalars['String']['input']>;
-  recipientIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  recipientListIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  sqlRecipientListIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  status: ConfigStatus;
-  title: Scalars['String']['input'];
+  newId: Scalars['String']['input'];
+  oldId: Scalars['String']['input'];
 };
 
 export type EqualFilterConfigKindInput = {

--- a/frontend/packages/system/src/Notifications/Pages/ColdChain/CCNotificationEditPage.tsx
+++ b/frontend/packages/system/src/Notifications/Pages/ColdChain/CCNotificationEditPage.tsx
@@ -15,7 +15,6 @@ import {
   parseColdChainNotificationConfig,
 } from './parseConfig';
 import { useUpdateNotificationConfig } from '../../api/hooks/useUpdateNotificationConfig';
-import { useDuplicateNotificationConfig } from '../../api/hooks/useDuplicateNotificationConfig';
 import {
   NotificationConfigRowFragment,
   useNotificationConfigs,
@@ -80,17 +79,9 @@ export const CCNotificationEditPage = () => {
   const { mutateAsync: update, isLoading: updateIsLoading } =
     useUpdateNotificationConfig();
 
-    const { mutateAsync: duplicate, isLoading: duplicateIsLoading } =
-    useDuplicateNotificationConfig();
-  
-    const onSave = async (draft: CCNotification) => {
+  const onSave = async (draft: CCNotification) => {
     const inputs = buildColdChainNotificationInputs(draft);
     await update({ input: inputs.update });
-  };
-
-  const onDuplicate = async (draft: CCNotification) => {
-    const inputs = buildColdChainNotificationInputs(draft);
-    await duplicate({ input: inputs.duplicate });
   };
 
   const isInvalid =
@@ -113,7 +104,6 @@ export const CCNotificationEditPage = () => {
       isLoading={isLoading || updateIsLoading}
       isInvalid={isInvalid}
       onSave={onSave}
-      onDuplicate={onDuplicate}
       draft={draft}
       setDraft={setDraft}
       CustomForm={CCNotificationEditForm}

--- a/frontend/packages/system/src/Notifications/Pages/ColdChain/parseConfig.ts
+++ b/frontend/packages/system/src/Notifications/Pages/ColdChain/parseConfig.ts
@@ -3,7 +3,6 @@ import {
   ConfigStatus,
   CreateNotificationConfigInput,
   UpdateNotificationConfigInput,
-  DuplicateNotificationConfigInput,
 } from '@common/types';
 import { CCNotification, ReminderUnits } from '../../types';
 import { NotificationConfigRowFragment } from '../../api';
@@ -17,8 +16,8 @@ export function parseColdChainNotificationConfig(
   try {
     return {
       ...defaultCCNotification,
-      ...config,
       ...JSON.parse(config.configurationData),
+      ...config,
     };
   } catch (e) {
     showError();
@@ -66,7 +65,6 @@ export const defaultCCNotification: CCNotification = {
 export function buildColdChainNotificationInputs(config: CCNotification): {
   create: CreateNotificationConfigInput;
   update: UpdateNotificationConfigInput;
-  duplicate: DuplicateNotificationConfigInput;
 } {
   const params = [];
   if (!Array.isArray(config.parsedParameters)) {
@@ -90,6 +88,5 @@ export function buildColdChainNotificationInputs(config: CCNotification): {
   return {
     create: { ...input, kind: config.kind },
     update: input,
-    duplicate: { ...input, kind: config.kind },
   };
 }

--- a/frontend/packages/system/src/Notifications/Pages/Scheduled/ScheduledNotificationEditPage.tsx
+++ b/frontend/packages/system/src/Notifications/Pages/Scheduled/ScheduledNotificationEditPage.tsx
@@ -4,10 +4,7 @@ import {
   useNotification,
   useParams,
   useBreadcrumbs,
-  FnUtils,
 } from '@notify-frontend/common';
-
-import { ConfigStatus } from '@common/types';
 
 import { ScheduledNotificationEditForm } from './ScheduledNotificationEditForm';
 import { BaseNotificationEditPage } from '../Base/BaseNotificationEditPage';
@@ -18,7 +15,6 @@ import {
   parseScheduledNotificationConfig,
 } from './parseConfig';
 import { useUpdateNotificationConfig } from '../../api/hooks/useUpdateNotificationConfig';
-import { useDuplicateNotificationConfig } from '../../api/hooks/useDuplicateNotificationConfig';
 import {
   NotificationConfigRowFragment,
   useNotificationConfigs,
@@ -54,22 +50,9 @@ export const ScheduledNotificationEditPage = () => {
   const { mutateAsync: update, isLoading: updateIsLoading } =
     useUpdateNotificationConfig();
 
-  const { mutateAsync: duplicate } =
-    useDuplicateNotificationConfig();
-
   const onSave = async (draft: ScheduledNotification) => {
     const inputs = buildScheduledNotificationInputs(draft);
     await update({ input: inputs.update });
-  };
-
-  const onDuplicate = async (draft: ScheduledNotification) => {
-    draft.id=FnUtils.generateUUID();
-    draft.title=draft.title + " Copy";
-    // want to check if there is the same title 
-
-    draft.status= ConfigStatus.Disabled;
-    const inputs = buildScheduledNotificationInputs(draft);
-    await duplicate({ input: inputs.duplicate });
   };
 
   const isInvalid =
@@ -86,7 +69,6 @@ export const ScheduledNotificationEditPage = () => {
       isInvalid={isInvalid}
       allowParameterSets={true}
       onSave={onSave}
-      onDuplicate={onDuplicate}
       draft={draft}
       setDraft={setDraft}
       CustomForm={ScheduledNotificationEditForm}

--- a/frontend/packages/system/src/Notifications/Pages/Scheduled/parseConfig.ts
+++ b/frontend/packages/system/src/Notifications/Pages/Scheduled/parseConfig.ts
@@ -3,7 +3,6 @@ import {
   ConfigStatus,
   CreateNotificationConfigInput,
   UpdateNotificationConfigInput,
-  DuplicateNotificationConfigInput,
 } from '@common/types';
 import { NotificationConfigRowFragment } from '../../api';
 import { ScheduledNotification } from '../../types';
@@ -17,8 +16,8 @@ export function parseScheduledNotificationConfig(
   try {
     return {
       ...defaultSchedulerNotification,
-      ...config,
       ...JSON.parse(config.configurationData),
+      ...config,
     };
   } catch (e) {
     showError();
@@ -58,9 +57,7 @@ export function buildScheduledNotificationInputs(
 ): {
   create: CreateNotificationConfigInput;
   update: UpdateNotificationConfigInput;
-  duplicate: DuplicateNotificationConfigInput;
 } {
-
   const params = [];
   if (!Array.isArray(config.parsedParameters)) {
     config.parsedParameters = [config.parsedParameters];
@@ -82,6 +79,5 @@ export function buildScheduledNotificationInputs(
   return {
     create: { ...input, kind: config.kind },
     update: input,
-    duplicate: { ...input, kind: config.kind},
   };
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->
 Suggested PR changes

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Uses the backend to duplicate configs, avoids need to have per plugin onDuplicate Function, adds a confirmation modal
