### PR TITLE
243 no scroll bar shows in the queries main page

### DIFF
--- a/frontend/packages/system/src/Notifications/Pages/Scheduled/ScheduledNotificationEditForm.tsx
+++ b/frontend/packages/system/src/Notifications/Pages/Scheduled/ScheduledNotificationEditForm.tsx
@@ -66,8 +66,18 @@ export const ScheduledNotificationEditForm = ({
           value={draft.bodyTemplate}
           onChange={e => onUpdate({ bodyTemplate: e.target.value })}
           label={t('label.body-template')}
-          InputProps={{ sx: { backgroundColor: 'background.menu' } }}
+          InputProps={{
+            sx: {
+              backgroundColor: 'background.menu',
+              textarea: {
+                resize: 'vertical',
+                overflow: 'scroll',
+              },
+            },
+          }}
           InputLabelProps={{ shrink: true }}
+          minRows={3}
+          maxRows={10}
         />
       </FormRow>
       <Box padding={1}>

--- a/frontend/packages/system/src/Queries/NotificationQueries/DetailEdit.tsx
+++ b/frontend/packages/system/src/Queries/NotificationQueries/DetailEdit.tsx
@@ -6,11 +6,9 @@ import {
 } from '@common/hooks';
 import {
   AppBarButtonsPortal,
-  AppBarContentPortal,
   BasicSpinner,
   Box,
   NothingHere,
-  Paper,
   Table,
   TableBody,
   TableCell,
@@ -51,7 +49,7 @@ export const DetailEdit = () => {
   const [generatedQuery, setGeneratedQuery] = React.useState('');
   const [queryError, setQueryErr] = React.useState('');
 
-  const initialiseQueryResults = () =>{
+  const initialiseQueryResults = () => {
     setQueryColumns([]);
     setSqlResults([]);
     setGeneratedQuery('');
@@ -63,9 +61,9 @@ export const DetailEdit = () => {
     await testNotificationQuery({ sqlQuery: query, params: params })
       .then(result => {
         const responseType = result.runSqlQueryWithParameters.__typename;
-        if (responseType == "NodeError"){
+        if (responseType == 'NodeError') {
           setGeneratedQuery('Error');
-        }else{
+        } else {
           const results = JSON.parse(result.runSqlQueryWithParameters.results);
           const columns = Object.keys(results[0] ?? []);
           // If we have an id column, move it to the front
@@ -77,7 +75,7 @@ export const DetailEdit = () => {
           }
           setQueryColumns(columns);
           setSqlResults(results);
-          if(result.runSqlQueryWithParameters.queryError){
+          if (result.runSqlQueryWithParameters.queryError) {
             setQueryErr(result.runSqlQueryWithParameters.queryError);
           }
           setGeneratedQuery(result.runSqlQueryWithParameters.query);
@@ -91,78 +89,71 @@ export const DetailEdit = () => {
   return (
     <>
       <AppBarButtonsPortal>{OpenButton}</AppBarButtonsPortal>
-      {/* Description/Details section */}
-      <AppBarContentPortal sx={{ paddingBottom: '16px', flex: 1 }}>
-        <Paper
-          sx={{
-            borderRadius: '16px',
-            boxShadow: theme => theme.shadows[1],
-            padding: '21px',
-            height: 'fit-content',
-            backgroundColor: 'background',
-            display: 'flex',
-            justifyContent: 'space-between',
-            gap: '16px',
-          }}
-        >
-          {entity && !isLoading ? (
-            <QueryEditor
-              entity={entity}
-              runQuery={runQuery}
-              queryLoading={queryLoading}
-              generatedQuery={generatedQuery}
-            />
-          ) : (
-            <BasicSpinner />
-          )}
-        </Paper>
-      </AppBarContentPortal>
+      {/* Query Editor */}
+      {entity && !isLoading ? (
+        <QueryEditor
+          entity={entity}
+          runQuery={runQuery}
+          queryLoading={queryLoading}
+          generatedQuery={generatedQuery}
+        />
+      ) : (
+        <BasicSpinner />
+      )}
       {/* Sql Results table */}
       <Box sx={{ width: '100%', display: 'flex', flexDirection: 'column' }}>
-        {queryError && (<AlertPanel message ={queryError}/>)}
-        {(generatedQuery && !queryError) && (<InfoPanel message = { t('messages.query-result-count', { count: sqlResults.length })}/>)}
-        {(!generatedQuery || queryError || sqlResults.length == 0) && (<NothingHere body={t('error.no-query-result')} />)}
-          <Table>
-            <TableHead 
-              sx={{
+        {queryError && <AlertPanel message={queryError} />}
+        {generatedQuery && !queryError && (
+          <InfoPanel
+            message={t('messages.query-result-count', {
+              count: sqlResults.length,
+            })}
+          />
+        )}
+        {(!generatedQuery || queryError || sqlResults.length == 0) && (
+          <NothingHere body={t('error.no-query-result')} />
+        )}
+        <Table>
+          <TableHead
+            sx={{
               backgroundColor: 'background.white',
               position: 'sticky',
               top: 0,
               zIndex: 'tableHeader',
             }}
           >
-              <TableRow>
+            <TableRow>
+              {queryColumns.map(column => (
+                <TableCell
+                  key={column}
+                  role="columnheader"
+                  sx={{
+                    backgroundColor: 'transparent',
+                    borderBottom: '0px',
+                    paddingLeft: '16px',
+                    paddingRight: '16px',
+                    fontWeight: 'bold',
+                    fontSize: '14px',
+                  }}
+                >
+                  {column}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {sqlResults.map((row, idx) => (
+              <TableRow key={`row-${idx}`}>
                 {queryColumns.map(column => (
-                  <TableCell
-                    key={column}
-                    role="columnheader"
-                    sx={{
-                      backgroundColor: 'transparent',
-                      borderBottom: '0px',
-                      paddingLeft: '16px',
-                      paddingRight: '16px',
-                      fontWeight: 'bold',
-                      fontSize: '14px',
-                    }}
-                  >
-                    {column}
+                  <TableCell key={`row-${idx}-${column}`}>
+                    {stringifyObjectKey(row[column])}
                   </TableCell>
                 ))}
               </TableRow>
-            </TableHead>
-            <TableBody>
-              {sqlResults.map((row, idx) => (
-                <TableRow key={`row-${idx}`}>
-                  {queryColumns.map(column => (
-                    <TableCell key={`row-${idx}-${column}`}>
-                      {stringifyObjectKey(row[column])}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </Box>
+            ))}
+          </TableBody>
+        </Table>
+      </Box>
     </>
   );
 };

--- a/frontend/packages/system/src/Queries/NotificationQueries/QueryEditor.tsx
+++ b/frontend/packages/system/src/Queries/NotificationQueries/QueryEditor.tsx
@@ -16,10 +16,14 @@ import {
   ZapIcon,
   isValidVariableName,
   useDetailPanel,
-  useToggle,
   useTranslation,
   validateVariableNameHelperText,
   useNotification,
+  AppFooterPortal,
+  AppBarContentPortal,
+  Paper,
+  useToggle,
+  Stack,
 } from '@notify-frontend/common';
 import { DraftNotificationQuery } from './types';
 import { useUpdateNotificationQuery } from '../api';
@@ -65,7 +69,6 @@ export const QueryEditor = ({
   const { open: openSidePanel, isOpen } = useDetailPanel();
 
   const [isSaved, setIsSaved] = useState(true);
-
   const {
     isOn: isEditingName,
     toggleOn: editNameToggleOn,
@@ -150,128 +153,160 @@ export const QueryEditor = ({
     );
   }
   return (
-    <Box sx={{ width: '100%' }}>
+    <>
       <SidePanel
         query={draft.query}
         queryParams={queryParams}
         onUpdateQueryParams={onUpdateQueryParams}
         generatedQuery={generatedQuery}
       />
-      <Grid flexDirection="column" display="flex" gap={1}>
-        {isEditingName ? (
-          <>
-            <BasicTextInput
-              autoFocus
-              required
-              value={draft.name}
-              error={invalidName(draft.name)}
-              helperText={
-                invalidName(draft.name)
-                  ? t('helper-text.recipient-list-name')
-                  : null
-              }
-              onChange={e => onUpdate({ name: e.target.value })}
-              label={t('label.name')}
-              InputLabelProps={{ shrink: true }}
-            />
-            <BasicTextInput
-              autoFocus
-              required
-              value={draft.referenceName}
-              error={!isValidVariableName(draft.referenceName)}
-              helperText={
-                <Tooltip title={t('helper-text.reference_name')}>
-                  <span>
-                    {validateVariableNameHelperText(draft.referenceName, t) ??
-                      t('helper-text.reference_name')}
-                  </span>
-                </Tooltip>
-              }
-              onChange={e => onUpdate({ referenceName: e.target.value })}
-              label={t('label.reference-name')}
-              InputLabelProps={{ shrink: true }}
-            />
-          </>
-        ) : (
-          <Typography
-            sx={{
-              fontSize: '18px',
-              fontWeight: 'bold',
-              color: 'gray.dark',
-            }}
-            onClick={editNameToggleOn}
-          >
-            {draft?.name} ({draft?.referenceName})
-            <IconButton
-              onClick={editNameToggleOn}
-              icon={<EditIcon />}
-              label={t('label.edit')}
-            />
-          </Typography>
-        )}
+      {/* Description/Details section */}
+      <AppBarContentPortal sx={{ paddingBottom: '16px', flex: 1 }}>
+        <Paper
+          sx={{
+            borderRadius: '16px',
+            boxShadow: theme => theme.shadows[1],
+            padding: '21px',
+            height: 'fit-content',
+            backgroundColor: 'background',
+          }}
+        >
+          {isEditingName ? (
+            <Stack>
+              <BasicTextInput
+                required
+                value={draft.name}
+                error={invalidName(draft.name)}
+                helperText={
+                  invalidName(draft.name)
+                    ? t('helper-text.recipient-list-name')
+                    : null
+                }
+                onChange={e => onUpdate({ name: e.target.value })}
+                label={t('label.name')}
+                InputLabelProps={{ shrink: true }}
+              />
+              <BasicTextInput
+                required
+                value={draft.referenceName}
+                error={!isValidVariableName(draft.referenceName)}
+                helperText={
+                  <Tooltip title={t('helper-text.reference_name')}>
+                    <span>
+                      {validateVariableNameHelperText(draft.referenceName, t) ??
+                        t('helper-text.reference_name')}
+                    </span>
+                  </Tooltip>
+                }
+                onChange={e => onUpdate({ referenceName: e.target.value })}
+                label={t('label.reference-name')}
+                InputLabelProps={{ shrink: true }}
+              />
 
-        <BufferedTextArea
-          value={draft.description}
-          onChange={e => onUpdate({ description: e.target.value })}
-          label={t('label.description')}
-          InputProps={{ sx: { backgroundColor: 'background.menu' } }}
-          InputLabelProps={{ shrink: true }}
-          rows={2}
-        />
-        <BufferedTextArea
-          value={draft.query}
-          onChange={e => onUpdate({ query: e.target.value })}
-          label={t('label.query')}
-          InputProps={{ sx: { backgroundColor: 'background.menu' } }}
-          InputLabelProps={{ shrink: true }}
-          helperText={t('helper-text.sql-query')}
-          minRows={4}
-        />
-        <Box sx={{ display: 'flex', gap: '8px' }}>
-          <Typography
-            component={'span'}
-            sx={{ fontWeight: 'bold', color: 'gray.dark' }}
-          >
-            {t('label.parameters')}:
-          </Typography>
-
-          {!hasParams ? (
-            <Typography component={'span'} sx={{ color: 'gray.light' }}>
-              {t('message.no-parameters')}
-            </Typography>
+              <BufferedTextArea
+                value={draft.description}
+                onChange={e => onUpdate({ description: e.target.value })}
+                label={t('label.description')}
+                InputProps={{ sx: { backgroundColor: 'background.menu' } }}
+                InputLabelProps={{ shrink: true }}
+                rows={4}
+              />
+            </Stack>
           ) : (
-            <>
-              <Typography component={'span'} sx={{ color: 'gray.dark' }}>
-                {TeraUtils.extractParams(draft.query).join(', ')}
-              </Typography>
+            <Typography
+              sx={{
+                fontSize: '18px',
+                fontWeight: 'bold',
+                color: 'gray.dark',
+              }}
+              onClick={editNameToggleOn}
+            >
+              {draft?.name} ({draft?.referenceName})
               <IconButton
-                height="24px"
-                width="24px"
-                onClick={openSidePanel}
+                onClick={editNameToggleOn}
                 icon={<EditIcon />}
                 label={t('label.edit')}
               />
-            </>
+            </Typography>
           )}
-        </Box>
-        <Box>
-          <LoadingButton
-            startIcon={<SaveIcon />}
-            onClick={() => {
-              onSave(draft).catch(err => {
-                console.error(err);
-                error(err)();
-              });
-            }}
-            disabled={isSaved || invalidName(draft.name)}
-            isLoading={updateIsLoading}
-            sx={{ marginRight: 1 }}
+
+          <Grid item xs={12}>
+            <BufferedTextArea
+              value={draft.query}
+              onChange={e => onUpdate({ query: e.target.value })}
+              label={t('label.query')}
+              InputProps={{
+                sx: {
+                  backgroundColor: 'background.menu',
+                  textarea: {
+                    resize: 'vertical',
+                  },
+                },
+              }}
+              InputLabelProps={{ shrink: true }}
+              helperText={t('helper-text.sql-query')}
+              minRows={4}
+              maxRows={10}
+            />
+          </Grid>
+        </Paper>
+      </AppBarContentPortal>
+
+      <AppFooterPortal
+        Content={
+          <Box
+            gap={2}
+            display="flex"
+            flexDirection="row"
+            alignItems="center"
+            height={64}
           >
-            {t('button.save')}
-          </LoadingButton>
-          {testQueryButton}
-        </Box>
-      </Grid>
-    </Box>
+            <Box flex={1} display="flex" justifyContent="flex-start" gap={1}>
+              <Typography
+                component={'span'}
+                sx={{ fontWeight: 'bold', color: 'gray.dark' }}
+              >
+                {t('label.parameters')}:
+              </Typography>
+              {!hasParams ? (
+                <Typography component={'span'} sx={{ color: 'gray.light' }}>
+                  {t('message.no-parameters')}
+                </Typography>
+              ) : (
+                <>
+                  <Typography component={'span'} sx={{ color: 'gray.dark' }}>
+                    {TeraUtils.extractParams(draft.query).join(', ')}
+                  </Typography>
+                  <IconButton
+                    height="24px"
+                    width="24px"
+                    onClick={openSidePanel}
+                    icon={<EditIcon />}
+                    label={t('label.edit')}
+                  />
+                </>
+              )}
+            </Box>
+            <Box flex={1} display="flex" justifyContent="flex-end" gap={2}>
+              {testQueryButton}
+              <LoadingButton
+                startIcon={<SaveIcon />}
+                onClick={() => {
+                  onSave(draft).catch(err => {
+                    console.error(err);
+                    error(err)();
+                  });
+                }}
+                disabled={isSaved || invalidName(draft.name)}
+                isLoading={updateIsLoading}
+                sx={{ marginRight: 1 }}
+              >
+                {t('button.save')}
+              </LoadingButton>
+            </Box>
+          </Box>
+        }
+      />
+    </>
   );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #243

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Makes it possible to scroll the query text box and sql results in the queries page.

![Kapture 2023-11-15 at 08 54 22](https://github.com/msupply-foundation/notify/assets/8287373/4baa05b3-eb23-450d-81ef-cf0ecf3d72da)

# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Example long query to use...
```
SELECT 
'a' as a,
'b' as b,
'c' as c,
'd' as d,
'e' as e,
'f' as f,
'g' as g,
'h' as h,
'i' as i,
'j' as j,
'k' as k,
'l' as l,
'm' as m,
'n' as n,
'o' as o,
'p' as p,
'q' as q,
'r' as r,
's' as s,
't' as t,
'u' as u,
'v' as v,
'w' as w,
'x' as x,
'y' as y,
'z' as z
FROM 
sensor
LIMIT 100
```

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->
It's a bit unintuitive to resize the textarea to make space for query results, but making the whole app bar scrollable seemed difficult. I experimented with side by side query and results but that also feels a bit messy and has issues with query and result sizes.

Hopefully this hits the balance of usable but not too difficult to implement :)
