### PR TITLE
249 email error can stop processing

### DIFF
--- a/backend/server/src/lib.rs
+++ b/backend/server/src/lib.rs
@@ -202,10 +202,13 @@ async fn run_server(
         _ = ctrl_c => false,
         Some(_) = off_switch.recv() => false,
         _ = restart_switch_receiver.recv() => true,
+        scheduled_error = scheduled_task_handle => {
+            error!("Scheduled task stopped unexpectedly: {:?}", scheduled_error);
+            false
+        }
     };
 
     server_handle.stop(true).await;
-    scheduled_task_handle.abort();
     Ok(restart)
 }
 

--- a/backend/service/src/email/mod.rs
+++ b/backend/service/src/email/mod.rs
@@ -94,7 +94,7 @@ impl EmailService {
                 .mail
                 .from
                 .parse()
-                .expect("The configured mail:from address is not valid"),
+                .expect("The configured mail:from address is not valid"), // This could panic on startup, but only if an invalid from address is configured
             url: settings.server.app_url,
         }
     }

--- a/backend/service/src/email/mod.rs
+++ b/backend/service/src/email/mod.rs
@@ -8,6 +8,7 @@ use lettre::{
     },
     SmtpTransport,
 };
+use std::time::Duration;
 
 use repository::{EmailQueueRowRepository, EmailQueueStatus, RepositoryError};
 
@@ -21,6 +22,7 @@ pub mod enqueue;
 pub mod send;
 
 pub static MAX_RETRIES: i32 = 3;
+pub static TIMEOUT_MS: u64 = 30_000; // 30 seconds
 
 // We use a trait for EmailService to allow mocking in tests
 pub trait EmailServiceTrait: Send + Sync {
@@ -82,7 +84,9 @@ impl EmailService {
             transport_builder = transport_builder.credentials(credentials);
         }
 
-        let mailer = transport_builder.build();
+        let mailer = transport_builder
+            .timeout(Some(Duration::from_millis(TIMEOUT_MS)))
+            .build();
 
         EmailService {
             mailer,
@@ -90,7 +94,7 @@ impl EmailService {
                 .mail
                 .from
                 .parse()
-                .expect("The configured mail:from address is not valid"), // This could panic on startup, but only if an invalid from address is configured
+                .expect("The configured mail:from address is not valid"),
             url: settings.server.app_url,
         }
     }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #249

Not sure if this really fixes the error we saw, as we don't have good logging, and I haven't been able to re-create it.
The closest I've come to is manually panicing in a plugin which does kill the scheduled task processing without stopping the whole server, so I've changed the behaviour so it does exit the server in this situation.

# 👩🏻‍💻 What does this PR do?

- [ ] Adds code to exit the server if a plugin, email, or other scheduled task process panics/unwraps/expects etc.
- [ ] Adds a timeout to lettre code, I think it already has this but just in case, added something, so it hopefullywon't hang forever


# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

I added a failing unwrap to scheduled task processing, this closed the join handle and caused the whole server to shutdown.
```
2023-11-17 17:21:35.674677000 [INFO] <actix_server::server:196>:Actix runtime found; starting in Actix runtime
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', scheduled/src/lib.rs:37:27
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2023-11-17 17:21:35.739012000 [ERROR] <server:206>:Scheduled task stopped unexpectedly: Err(JoinError::Panic(Id(3), ...))
2023-11-17 17:21:35.739145000 [INFO] <actix_server::accept:143>:Accept thread stopped
2023-11-17 17:21:35.739271000 [INFO] <actix_server::worker:593>:Shutting down idle worker
2023-11-17 17:21:35.739354000 [INFO] <actix_server::worker:593>:Shutting down idle worker
2023-11-17 17:21:35.739406000 [INFO] <actix_server::worker:593>:Shutting down idle worker
2023-11-17 17:21:35.739483000 [INFO] <actix_server::worker:593>:Shutting down idle worker
2023-11-17 17:21:35.739591000 [INFO] <actix_server::worker:593>:Shutting down idle worker
2023-11-17 17:21:35.739661000 [INFO] <actix_server::worker:593>:Shutting down idle worker
2023-11-17 17:21:35.739745000 [INFO] <actix_server::worker:593>:Shutting down idle worker
2023-11-17 17:21:35.739850000 [INFO] <actix_server::worker:593>:Shutting down idle worker
2023-11-17 17:21:35.739917000 [INFO] <actix_server::worker:593>:Shutting down idle worker
2023-11-17 17:21:35.739972000 [INFO] <actix_server::worker:593>:Shutting down idle worker
2023-11-17 17:21:35.740138000 [INFO] <server:277>:Remote server stopped
```

We could also restart in this situation, but I'm thinking if we exit we aleast know something is wrong rather than going into an infinite restart loop.

Would be interested in a restart option, but would like to keep some kind of state so we only try to restart 5 times or something?

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

I tried to experiment with adding some kind of timeout to the plugin and notification sending calls.
Seems hard, would be good to peer program it with someone perhaps? Related to https://github.com/msupply-foundation/notify/issues/133