### PR TITLE
253 fix escaping in logs

### DIFF
--- a/frontend/packages/system/src/Notifications/Pages/ColdChain/parseConfig.ts
+++ b/frontend/packages/system/src/Notifications/Pages/ColdChain/parseConfig.ts
@@ -14,10 +14,12 @@ export function parseColdChainNotificationConfig(
 ): CCNotification | null {
   if (!config) return null;
   try {
+    const { configurationData, ...rest } = config;
+
     return {
       ...defaultCCNotification,
-      ...JSON.parse(config.configurationData),
-      ...config,
+      ...JSON.parse(configurationData),
+      ...rest,
     };
   } catch (e) {
     showError();

--- a/frontend/packages/system/src/Notifications/Pages/Scheduled/parseConfig.ts
+++ b/frontend/packages/system/src/Notifications/Pages/Scheduled/parseConfig.ts
@@ -14,10 +14,12 @@ export function parseScheduledNotificationConfig(
 ): ScheduledNotification | null {
   if (!config) return null;
   try {
+    const { configurationData, ...rest } = config;
+
     return {
       ...defaultSchedulerNotification,
-      ...JSON.parse(config.configurationData),
-      ...config,
+      ...JSON.parse(configurationData),
+      ...rest,
     };
   } catch (e) {
     showError();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #253

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Turns out it wasn't a parsing/escaping issue... we weren't removing the old `configurationData` field from the config after it was parsed, so each time we saved the new `configurationData`, we included a child field of the previous `configurationData` - ah recursion!

# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

- Create a new notification config, enable it, and click `Save and Run` a bunch of times
- View the log of the mutation input... configuration data should stay the same size :)

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

This doesn't fix the configuration data for all the configs that already have this nested stringified configuration data, but it does stop them growing any further. That should be fine right?

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_


