### PR TITLE
245 telegram markdown is not rendered correctly

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3598,6 +3598,8 @@ version = "0.1.0"
 dependencies = [
  "http",
  "log",
+ "pulldown-cmark",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/backend/service/src/notification/mod.rs
+++ b/backend/service/src/notification/mod.rs
@@ -201,8 +201,13 @@ impl NotificationServiceTrait for NotificationService {
                 NotificationType::Telegram => {
                     // Try to send via telegram
                     if let Some(telegram) = &ctx.service_provider.telegram {
+                        let telegram_markdown_v2 =
+                            telegram::service::markdown::cmark_to_telegram_v2(
+                                &notification.message,
+                            );
+
                         let result = telegram
-                            .send_markdown_message(&notification.to_address, &notification.message)
+                            .send_markdown_message(&notification.to_address, &telegram_markdown_v2)
                             .await;
 
                         match result {

--- a/backend/telegram/Cargo.toml
+++ b/backend/telegram/Cargo.toml
@@ -14,6 +14,8 @@ tokio = { version = "1", features = ["macros"] }
 serde_json = "1.0.66"
 serde = { version = "1.0.126", features = ["derive"] }
 log = "0.4.14"
+pulldown-cmark = { version = "0.9", default-features = false }
+regex = "1"
 
 [features]
 telegram-tests = []

--- a/backend/telegram/src/client/mod.rs
+++ b/backend/telegram/src/client/mod.rs
@@ -207,9 +207,6 @@ impl TelegramClient {
 }
 
 #[cfg(test)]
-mod test {}
-
-#[cfg(test)]
 #[cfg(feature = "telegram-tests")]
 mod telegram_test {
     use super::*;

--- a/backend/telegram/src/client/mod.rs
+++ b/backend/telegram/src/client/mod.rs
@@ -118,16 +118,15 @@ impl TelegramClient {
         Ok(chat)
     }
 
+    /// Sends a telegram MarkdownV2 message, to translate from common markdown to telegram markdown see: markdown::cmark_telegram_v2
     pub async fn send_markdown_message(
         &self,
         chat_id: &str,
-        markdown: &str,
+        markdown_v2: &str,
     ) -> Result<TelegramMessage, TelegramError> {
-        let escaped_markdown = escape_telegram_markdown(markdown);
-
         let params = [
             ("chat_id", chat_id),
-            ("text", &escaped_markdown),
+            ("text", &markdown_v2),
             ("parse_mode", "MarkdownV2"),
         ];
         let url = format!("{}/sendMessage", self.base_url);
@@ -207,37 +206,8 @@ impl TelegramClient {
     }
 }
 
-// In all other places characters '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!' must be escaped with the preceding character '\'.
-// https://core.telegram.org/bots/api#markdownv2-style
-// This is kind of a bug, as we are escaping the characters that need to be escaped, but don't know when they shouldnt be escaped (e.g part of a markdown entity)
-// Deliberately not escaping ` so we can write preformatted stuff like ```code```
-fn escape_telegram_markdown(text: &str) -> String {
-    let mut escaped_text = String::new();
-    for c in text.chars() {
-        match c {
-            '_' | '*' | '[' | ']' | '(' | ')' | '~' | '>' | '#' | '+' | '-' | '=' | '|' | '{'
-            | '}' | '.' | '!' => {
-                escaped_text.push('\\');
-                escaped_text.push(c);
-            }
-            _ => escaped_text.push(c),
-        }
-    }
-    escaped_text
-}
-
 #[cfg(test)]
-mod test {
-
-    use super::*;
-
-    #[test]
-    fn test_escape_telegram_markdown() {
-        let text = "This is a test of _markdown_ escaping";
-        let escaped_text = escape_telegram_markdown(text);
-        assert_eq!(escaped_text, "This is a test of \\_markdown\\_ escaping");
-    }
-}
+mod test {}
 
 #[cfg(test)]
 #[cfg(feature = "telegram-tests")]

--- a/backend/telegram/src/service/markdown.rs
+++ b/backend/telegram/src/service/markdown.rs
@@ -1,0 +1,360 @@
+/*
+   This module is used to parse common markdown text to telegram safe markdown
+*/
+
+use pulldown_cmark::{html, Event, Parser};
+use reqwest::Url;
+
+/*
+MarkdownV2 style
+To use this mode, pass MarkdownV2 in the parse_mode field. Use the following syntax in your message:
+
+*bold \*text*
+_italic \*text_
+__underline__
+~strikethrough~
+||spoiler||
+*bold _italic bold ~italic bold strikethrough ||italic bold strikethrough spoiler||~ __underline italic bold___ bold*
+[inline URL](http://www.example.com/)
+[inline mention of a user](tg://user?id=123456789)
+![👍](tg://emoji?id=5368324170671202286)
+`inline fixed-width code`
+```
+pre-formatted fixed-width code block
+```
+```python
+pre-formatted fixed-width code block written in the Python programming language
+```
+Please note:
+
+Any character with code between 1 and 126 inclusively can be escaped anywhere with a preceding '\' character, in which case it is treated as an ordinary character and not a part of the markup. This implies that '\' character usually must be escaped with a preceding '\' character.
+Inside pre and code entities, all '`' and '\' characters must be escaped with a preceding '\' character.
+Inside the (...) part of the inline link and custom emoji definition, all ')' and '\' must be escaped with a preceding '\' character.
+In all other places characters '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!' must be escaped with the preceding character '\'.
+In case of ambiguity between italic and underline entities __ is always greadily treated from left to right as beginning or end of underline entity, so instead of ___italic underline___ use ___italic underline_\r__, where \r is a character with code 13, which will be ignored.
+A valid emoji must be provided as an alternative value for the custom emoji. The emoji will be shown instead of the custom emoji in places where a custom emoji cannot be displayed (e.g., system notifications) or if the message is forwarded by a non-premium user. It is recommended to use the emoji from the emoji field of the custom emoji sticker.
+Custom emoji entities can only be used by bots that purchased additional usernames on Fragment.
+https://core.telegram.org/bots/api#markdownv2-style
+*/
+pub fn cmark_to_telegram_v2(common_markdown: &str) -> String {
+    let parser = Parser::new(common_markdown);
+
+    let mut t_markdown_v2 = String::new();
+
+    let parser = parser.map(|event| {
+        match &event {
+            Event::Text(text) => {
+                // DEBUG EVENT: println!Text: {:?}", text);
+                if is_url(&text) {
+                    // If it's a URL, we don't want to escape it
+                    t_markdown_v2.push_str(&text);
+                } else {
+                    t_markdown_v2.push_str(&escape_telegram_markdown(&text));
+                }
+            }
+            Event::Start(pulldown_cmark::Tag::Paragraph) => {
+                // DEBUG EVENT: println!Start Paragraph");
+                // DO NOTHING! We'll end the paragraph with a double newline instead
+            }
+            Event::End(pulldown_cmark::Tag::Paragraph) => {
+                // DEBUG EVENT: println!End Paragraph");
+                t_markdown_v2.push_str("\n\n");
+            }
+            Event::Start(pulldown_cmark::Tag::Emphasis) => {
+                // DEBUG EVENT: println!Start Emphasis");
+                t_markdown_v2.push_str("_");
+            }
+            Event::End(pulldown_cmark::Tag::Emphasis) => {
+                // DEBUG EVENT: println!End Emphasis");
+                t_markdown_v2.push_str("_");
+            }
+            Event::Start(pulldown_cmark::Tag::Strong) => {
+                // DEBUG EVENT: println!Start Strong");
+                t_markdown_v2.push_str("*");
+            }
+            Event::End(pulldown_cmark::Tag::Strong) => {
+                // DEBUG EVENT: println!End Strong");
+                t_markdown_v2.push_str("*");
+            }
+            Event::Start(pulldown_cmark::Tag::CodeBlock(kind)) => {
+                // DEBUG EVENT: println!Start Code Block");
+                match kind {
+                    pulldown_cmark::CodeBlockKind::Indented => {
+                        // DEBUG EVENT: println!Start Indented Code Block");
+                        t_markdown_v2.push_str("```");
+                    }
+                    pulldown_cmark::CodeBlockKind::Fenced(language) => {
+                        // DEBUG EVENT: println!Start Fenced Code Block");
+                        t_markdown_v2.push_str("```");
+                        t_markdown_v2.push_str(&language);
+                        t_markdown_v2.push_str("\n");
+                    }
+                }
+            }
+            Event::End(pulldown_cmark::Tag::CodeBlock(_kind)) => {
+                // DEBUG EVENT: println!End Code Block");
+                t_markdown_v2.push_str("```");
+            }
+            Event::Start(pulldown_cmark::Tag::Link(link_type, _url, _title)) => {
+                // DEBUG EVENT: println!Start Link");
+
+                match link_type {
+                    pulldown_cmark::LinkType::Inline => {
+                        // DEBUG EVENT: println!Inline Link");
+                        // Inline Links send their title as a text event, so we just open the markdown link here ...
+                        t_markdown_v2.push_str("[");
+                    }
+                    pulldown_cmark::LinkType::Autolink => {
+                        // DEBUG EVENT: println!Autolink");
+                        // Autolinks are just a URL, so we'll add the url as the text, and the url as the link
+                        t_markdown_v2.push_str("[");
+                    }
+                    _ => {
+                        // DEBUG EVENT: println!Other Link");
+                        t_markdown_v2.push_str("[");
+                    }
+                };
+            }
+            Event::End(pulldown_cmark::Tag::Link(link_type, url, _title)) => {
+                // DEBUG EVENT: println!End Link");
+                match link_type {
+                    pulldown_cmark::LinkType::Inline => {
+                        // DEBUG EVENT: println!Inline Link");
+                        // Inline Links send their title as a text event, so we just close out the markdown link here ...
+                        t_markdown_v2.push_str("](");
+                        t_markdown_v2.push_str(&url);
+                        t_markdown_v2.push_str(")");
+                    }
+                    _ => {
+                        // Close out any other kind of weird link!
+                        t_markdown_v2.push_str("](");
+                        t_markdown_v2.push_str(&url);
+                        t_markdown_v2.push_str(")");
+                    }
+                };
+            }
+            Event::Code(text) => {
+                // DEBUG EVENT: println!Code: {:?}", text);
+                // An inline code node - https://docs.rs/pulldown-cmark/latest/pulldown_cmark/enum.Event.html
+                t_markdown_v2.push_str("`");
+                t_markdown_v2.push_str(&text);
+                t_markdown_v2.push_str("`");
+            }
+            Event::Html(text) => {
+                // DEBUG EVENT: println!HTML: {:?}", text);
+
+                // It's not clear what to do with this, but it's not supported by telegram markdown
+                // We'll put it in a pre block?
+                t_markdown_v2.push_str("```");
+                t_markdown_v2.push_str(&escape_telegram_markdown(&text)); // TODO: Escape this or not?
+                t_markdown_v2.push_str("```");
+            }
+            Event::FootnoteReference(text) => {
+                t_markdown_v2.push_str(&escape_telegram_markdown(&text));
+            }
+            Event::SoftBreak => {
+                t_markdown_v2.push_str("\n");
+            }
+            Event::HardBreak => {
+                t_markdown_v2.push_str("\n\n");
+            }
+            Event::Rule => {
+                t_markdown_v2.push_str("\n-----\n");
+            }
+            Event::Start(pulldown_cmark::Tag::Heading(_, _, _)) => {
+                // DEBUG EVENT: println!Start Heading");
+                // Telegram doesn't support headings, so we'll just do Bold Underline
+                t_markdown_v2.push_str("*__");
+            }
+            Event::End(pulldown_cmark::Tag::Heading(_, _, _)) => {
+                // DEBUG EVENT: println!End Heading");
+                // Telegram doesn't support headings, so we'll just do Bold Underline
+                t_markdown_v2.push_str("__*");
+            }
+            Event::Start(_tag) => {
+                // Telegram doesn't support this, and we're not going to bother with it
+                log::error!("Unknown Tag: {:?} in Telegram Markdown Parser", _tag);
+            }
+            Event::End(_tag) => {
+                // Telegram doesn't support this, and we're not going to bother with it
+                log::error!("Unknown End Tag: {:?} in Telegram Markdown Parser", _tag);
+            }
+            _ => {
+                log::error!("Unknown Event: {:?} in Telegram Markdown Parser", event);
+                // Telegram doesn't support some of these, so we'll just do nothing, and hope some text appears
+            }
+        };
+        event
+    });
+
+    // Process the events but creating an html output...
+    // This is needed to trigger the parser, there's probably a better way, but this works for now
+    let mut html_output = String::new();
+    html::push_html(&mut html_output, parser);
+
+    return t_markdown_v2
+        .strip_suffix("\n\n")
+        .unwrap_or(&t_markdown_v2)
+        .to_string();
+}
+
+// In all other places characters '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!' must be escaped with the preceding character '\'.
+// https://core.telegram.org/bots/api#markdownv2-style
+fn escape_telegram_markdown(text: &str) -> String {
+    let mut escaped_text = String::new();
+    for c in text.chars() {
+        match c {
+            '_' | '*' | '[' | ']' | '(' | ')' | '~' | '>' | '#' | '+' | '-' | '=' | '|' | '{'
+            | '`' | '}' | '.' | '!' | '\\' => {
+                escaped_text.push('\\');
+                escaped_text.push(c);
+            }
+            _ => escaped_text.push(c),
+        }
+    }
+    escaped_text
+}
+
+// Function to determine if a string is a valid URL
+// Used to determine if we should escape a string or not.
+// Telegram says to escape characters in a URL, but we don't want to do that if it's a URL
+fn is_url(text: &str) -> bool {
+    let result = Url::parse(text);
+    result.is_ok()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    // Test basic Bold
+    #[test]
+    fn test_cmark_telegram_v2_bold() {
+        let cmarkdown = "**bold * text**";
+        let expected = "*bold \\* text*"; // Single star to say it's bold, and escaped star in the middle
+        let result = cmark_to_telegram_v2(cmarkdown);
+        assert_eq!(result, expected);
+    }
+
+    // Test basic Italic
+    #[test]
+    fn test_cmark_telegram_v2_italic() {
+        let cmarkdown = "_italic * text_";
+        let expected = "_italic \\* text_"; // Single underscore to say it's emphasis, and escaped star in the middle
+        let result = cmark_to_telegram_v2(cmarkdown);
+        assert_eq!(result, expected);
+    }
+
+    //~strikethrough~
+    #[test]
+    fn test_cmark_telegram_v2_strikethrough() {
+        let cmarkdown = "~strikethrough~";
+        // NOTE: This isn't ideal, would be good if it would show as strike through in telegram and not escape it. Could improve in future?
+        let expected = "\\~strikethrough\\~"; // Single star to say it's bold, and escaped star in the middle
+        let result = cmark_to_telegram_v2(cmarkdown);
+        assert_eq!(result, expected);
+    }
+
+    // ||spoiler||
+    #[test]
+    fn test_cmark_telegram_v2_spoiler() {
+        let cmarkdown = "||spoiler||";
+        // NOTE: This isn't ideal, would be good if it would show as spoiler in telegram and not escape it. Could improve in future?
+        let expected = "\\|\\|spoiler\\|\\|"; // Single star to say it's bold, and escaped star in the middle
+        let result = cmark_to_telegram_v2(cmarkdown);
+        assert_eq!(result, expected);
+    }
+
+    // Bold, Italic
+    #[test]
+    fn test_cmark_telegram_v2_bold_italic() {
+        let cmarkdown = "**bold _italic_ bold**";
+        let expected = "*bold _italic_ bold*";
+        let result = cmark_to_telegram_v2(cmarkdown);
+        assert_eq!(result, expected);
+    }
+
+    // Include a link
+    #[test]
+    fn test_cmark_telegram_v2_links() {
+        let cmarkdown = "[inline URL](http://www.example.com/)";
+        let expected = "[inline URL](http://www.example.com/)";
+        let result = cmark_to_telegram_v2(cmarkdown);
+        assert_eq!(result, expected);
+
+        // Auto Link
+        let cmarkdown = "<http://www.example.com/>";
+        let expected = "[http://www.example.com/](http://www.example.com/)";
+        let result = cmark_to_telegram_v2(cmarkdown);
+        assert_eq!(result, expected);
+
+        // No Link
+        let cmarkdown = "http://www.example.com/";
+        let expected = "http://www.example.com/";
+        let result = cmark_to_telegram_v2(cmarkdown);
+        assert_eq!(result, expected);
+    }
+
+    // Pre-formatted fixed-width code block
+    #[test]
+    fn test_cmark_telegram_v2_code() {
+        let cmarkdown = "`inline code`";
+        let expected = "`inline code`";
+        let result = cmark_to_telegram_v2(cmarkdown);
+        assert_eq!(result, expected);
+
+        // Multiline Code
+        let cmarkdown = r#"```
+Line1
+Line2
+Line3
+```"#; // Line needs to start with ``` for the parser to pick it up (aka don't indent this!)
+        let expected = "```\nLine1\nLine2\nLine3\n```";
+        let result = cmark_to_telegram_v2(cmarkdown);
+        assert_eq!(result, expected);
+    }
+
+    // Cold Chain Example
+    #[test]
+    fn test_cmark_telegram_v2_cc() {
+        // example cold chain markdown
+        let cmarkdown = r#"**Sensor is now ok!**
+
+**Facility**: Facility
+**Location**: location_name
+**Sensor**: sensor_name
+
+**Date**:  22 Feb 2021
+**Time**:  16:20
+**Temperature**: 5.10°C
+**Last data received**: 2 hours ago
+"#; // Don't indent this!
+        let expected = r#"*Sensor is now ok\!*
+
+*Facility*: Facility
+*Location*: location\_name
+*Sensor*: sensor\_name
+
+*Date*:  22 Feb 2021
+*Time*:  16:20
+*Temperature*: 5\.10°C
+*Last data received*: 2 hours ago"#; // Don't indent this!
+        let result = cmark_to_telegram_v2(cmarkdown);
+        assert_eq!(result, expected);
+    }
+
+    // Test emoji!
+    #[test]
+    fn test_cmark_telegram_v2_emoji() {
+        let cmarkdown = "👍";
+        let expected = "👍";
+        let result = cmark_to_telegram_v2(cmarkdown);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_escape_telegram_markdown() {
+        let text = "This is a test of markdown - escaping";
+        let escaped_text = escape_telegram_markdown(text);
+        assert_eq!(escaped_text, "This is a test of markdown \\- escaping");
+    }
+}

--- a/backend/telegram/src/service/markdown.rs
+++ b/backend/telegram/src/service/markdown.rs
@@ -44,7 +44,7 @@ pub fn cmark_to_telegram_v2(common_markdown: &str) -> String {
     let parser = parser.map(|event| {
         match &event {
             Event::Text(text) => {
-                // DEBUG EVENT: println!Text: {:?}", text);
+                // DEBUG EVENT: println!("Text: {:?}", text);
                 if is_url(&text) {
                     // If it's a URL, we don't want to escape it
                     t_markdown_v2.push_str(&text);
@@ -53,38 +53,38 @@ pub fn cmark_to_telegram_v2(common_markdown: &str) -> String {
                 }
             }
             Event::Start(pulldown_cmark::Tag::Paragraph) => {
-                // DEBUG EVENT: println!Start Paragraph");
+                // DEBUG EVENT: println!("Start Paragraph");
                 // DO NOTHING! We'll end the paragraph with a double newline instead
             }
             Event::End(pulldown_cmark::Tag::Paragraph) => {
-                // DEBUG EVENT: println!End Paragraph");
+                // DEBUG EVENT: println!("End Paragraph");
                 t_markdown_v2.push_str("\n\n");
             }
             Event::Start(pulldown_cmark::Tag::Emphasis) => {
-                // DEBUG EVENT: println!Start Emphasis");
+                // DEBUG EVENT: println!("Start Emphasis");
                 t_markdown_v2.push_str("_");
             }
             Event::End(pulldown_cmark::Tag::Emphasis) => {
-                // DEBUG EVENT: println!End Emphasis");
+                // DEBUG EVENT: println!("End Emphasis");
                 t_markdown_v2.push_str("_");
             }
             Event::Start(pulldown_cmark::Tag::Strong) => {
-                // DEBUG EVENT: println!Start Strong");
+                // DEBUG EVENT: println!("Start Strong");
                 t_markdown_v2.push_str("*");
             }
             Event::End(pulldown_cmark::Tag::Strong) => {
-                // DEBUG EVENT: println!End Strong");
+                // DEBUG EVENT: println!("End Strong");
                 t_markdown_v2.push_str("*");
             }
             Event::Start(pulldown_cmark::Tag::CodeBlock(kind)) => {
-                // DEBUG EVENT: println!Start Code Block");
+                // DEBUG EVENT: println!("Start Code Block");
                 match kind {
                     pulldown_cmark::CodeBlockKind::Indented => {
-                        // DEBUG EVENT: println!Start Indented Code Block");
+                        // DEBUG EVENT: println!("Start Indented Code Block");
                         t_markdown_v2.push_str("```");
                     }
                     pulldown_cmark::CodeBlockKind::Fenced(language) => {
-                        // DEBUG EVENT: println!Start Fenced Code Block");
+                        // DEBUG EVENT: println!("Start Fenced Code Block");
                         t_markdown_v2.push_str("```");
                         t_markdown_v2.push_str(&language);
                         t_markdown_v2.push_str("\n");
@@ -92,61 +92,37 @@ pub fn cmark_to_telegram_v2(common_markdown: &str) -> String {
                 }
             }
             Event::End(pulldown_cmark::Tag::CodeBlock(_kind)) => {
-                // DEBUG EVENT: println!End Code Block");
+                // DEBUG EVENT: println!("End Code Block");
                 t_markdown_v2.push_str("```");
             }
-            Event::Start(pulldown_cmark::Tag::Link(link_type, _url, _title)) => {
-                // DEBUG EVENT: println!Start Link");
+            Event::Start(pulldown_cmark::Tag::Link(_link_type, _url, _title)) => {
+                // DEBUG EVENT: println!("Start Link");
 
-                match link_type {
-                    pulldown_cmark::LinkType::Inline => {
-                        // DEBUG EVENT: println!Inline Link");
-                        // Inline Links send their title as a text event, so we just open the markdown link here ...
-                        t_markdown_v2.push_str("[");
-                    }
-                    pulldown_cmark::LinkType::Autolink => {
-                        // DEBUG EVENT: println!Autolink");
-                        // Autolinks are just a URL, so we'll add the url as the text, and the url as the link
-                        t_markdown_v2.push_str("[");
-                    }
-                    _ => {
-                        // DEBUG EVENT: println!Other Link");
-                        t_markdown_v2.push_str("[");
-                    }
-                };
+                // The link title is sent as a text event in most cases, so we'll just open the markdown link here
+                t_markdown_v2.push_str("[");
             }
-            Event::End(pulldown_cmark::Tag::Link(link_type, url, _title)) => {
-                // DEBUG EVENT: println!End Link");
-                match link_type {
-                    pulldown_cmark::LinkType::Inline => {
-                        // DEBUG EVENT: println!Inline Link");
-                        // Inline Links send their title as a text event, so we just close out the markdown link here ...
-                        t_markdown_v2.push_str("](");
-                        t_markdown_v2.push_str(&url);
-                        t_markdown_v2.push_str(")");
-                    }
-                    _ => {
-                        // Close out any other kind of weird link!
-                        t_markdown_v2.push_str("](");
-                        t_markdown_v2.push_str(&url);
-                        t_markdown_v2.push_str(")");
-                    }
-                };
+            Event::End(pulldown_cmark::Tag::Link(_link_type, url, _title)) => {
+                // DEBUG EVENT: println!("End Link");
+
+                // Inline and other Links send their title as a text event, so we just close out the markdown link here, and use the URL ...
+                t_markdown_v2.push_str("](");
+                t_markdown_v2.push_str(&url);
+                t_markdown_v2.push_str(")");
             }
             Event::Code(text) => {
-                // DEBUG EVENT: println!Code: {:?}", text);
+                // DEBUG EVENT: println!("Code: {:?}", text);
                 // An inline code node - https://docs.rs/pulldown-cmark/latest/pulldown_cmark/enum.Event.html
                 t_markdown_v2.push_str("`");
                 t_markdown_v2.push_str(&text);
                 t_markdown_v2.push_str("`");
             }
             Event::Html(text) => {
-                // DEBUG EVENT: println!HTML: {:?}", text);
+                // DEBUG EVENT: println!("HTML: {:?}", text);
 
                 // It's not clear what to do with this, but it's not supported by telegram markdown
-                // We'll put it in a pre block?
+                // We'll put it in a code block?
                 t_markdown_v2.push_str("```");
-                t_markdown_v2.push_str(&escape_telegram_markdown(&text)); // TODO: Escape this or not?
+                t_markdown_v2.push_str(&escape_telegram_markdown(&text)); // Not sure if it's best escape this or not, playing it safe...
                 t_markdown_v2.push_str("```");
             }
             Event::FootnoteReference(text) => {
@@ -162,14 +138,14 @@ pub fn cmark_to_telegram_v2(common_markdown: &str) -> String {
                 t_markdown_v2.push_str("\n-----\n");
             }
             Event::Start(pulldown_cmark::Tag::Heading(_, _, _)) => {
-                // DEBUG EVENT: println!Start Heading");
+                // DEBUG EVENT: println!("Start Heading");
                 // Telegram doesn't support headings, so we'll just do Bold Underline
                 t_markdown_v2.push_str("*__");
             }
             Event::End(pulldown_cmark::Tag::Heading(_, _, _)) => {
-                // DEBUG EVENT: println!End Heading");
+                // DEBUG EVENT: println!("End Heading");
                 // Telegram doesn't support headings, so we'll just do Bold Underline
-                t_markdown_v2.push_str("__*");
+                t_markdown_v2.push_str("__*\n");
             }
             Event::Start(_tag) => {
                 // Telegram doesn't support this, and we're not going to bother with it

--- a/backend/telegram/src/service/mod.rs
+++ b/backend/telegram/src/service/mod.rs
@@ -4,6 +4,7 @@ use crate::TelegramClient;
 
 use self::processor::poll_get_updates;
 
+pub mod markdown;
 mod processor;
 mod responder;
 

--- a/backend/templates/coldchain/recovered.md
+++ b/backend/templates/coldchain/recovered.md
@@ -1,4 +1,4 @@
-**Sensor is now ok!**
+**✅ Sensor is now ok!**
 
 **Facility**: {{ store_name }}
 {% if location_name %}

--- a/backend/templates/coldchain/temperature.md
+++ b/backend/templates/coldchain/temperature.md
@@ -1,4 +1,4 @@
-**{{ alert_type }} temperature alert!**
+**{% if alert_type == "High" %}🔥{% else %}❄️{% endif %} {{ alert_type }} temperature alert!**
 
 **Facility**: {{ store_name }}
 {% if location_name %}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #245 
Closes #230 

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

- [ ] Parses common markdown format into something that will mostly work on for Telegram
- [ ] Adds emoji to cold chain templates (mainly to demonstrate this does actually work)

**BEFORE**
![image](https://github.com/msupply-foundation/notify/assets/8287373/83d75dd6-b874-46a2-820a-d7c8865c295b)


**AFTER**
![image](https://github.com/msupply-foundation/notify/assets/8287373/6955cc42-7eae-4768-a349-3527274e39f6)


# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Some test cases are in the code, And have done a bit of testing with cold chain and other formats.
Would be good to do more testing though!

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

There's a few telegram things like `~strikethrough~` and `||spoiler||` that are in telegram but not in common markdown.
Would be nice to not escape those things so that they correctly display if someone is writing telegram style markdown.
I'm thinking this can be a wait to see/hear what issues people face before doing more though.

BTW: This is already a bit of a time sink, and we'll never get a perfect representation of everything in telegram :(
