### PR TITLE
#229 Remember Parameters

### DIFF
--- a/frontend/packages/common/src/intl/locales/en/system.json
+++ b/frontend/packages/common/src/intl/locales/en/system.json
@@ -53,6 +53,7 @@
   "label.notification-type-TELEGRAM": "Telegram",
   "label.notification-type-UNKNOWN": "ERROR-UNSUPPORTED-NOTIFICATION-TYPE",
   "label.parameters-query-results": "Parameters and Query Results",
+  "label.parameters-save-local":"Save parameters in local storage",
   "label.password-strength": "Password Strength",
   "label.password-warning": "Warning",
   "label.phone-number": "Phone Number",

--- a/frontend/packages/common/src/localStorage/keys.ts
+++ b/frontend/packages/common/src/localStorage/keys.ts
@@ -1,6 +1,7 @@
 import { SupportedLocales } from '@common/intl';
 import { ThemeOptions } from '@mui/material';
 import { AuthError } from '../authentication/AuthContext';
+import { KeyedParams } from '@common/utils';
 
 export type GroupByItem = {
   outboundShipment?: boolean;
@@ -19,6 +20,7 @@ export type LocalStorageRecord = {
   '/theme/logo': string;
   '/mru/credentials': AuthenticationCredentials;
   '/auth/error': AuthError | undefined;
+  '/query_parameters': KeyedParams;
 };
 
 export type LocalStorageKey = keyof LocalStorageRecord;

--- a/frontend/packages/system/src/Queries/NotificationQueries/QueryEditor.tsx
+++ b/frontend/packages/system/src/Queries/NotificationQueries/QueryEditor.tsx
@@ -123,7 +123,6 @@ export const QueryEditor = ({
 
   const allParamsSet = TeraUtils.extractParams(draft.query).every(param => {
     return queryParams[param] !== (undefined && "");
-    //if (param) {}
   });
 
   let testQueryButton = (

--- a/frontend/packages/system/src/Queries/NotificationQueries/QueryEditor.tsx
+++ b/frontend/packages/system/src/Queries/NotificationQueries/QueryEditor.tsx
@@ -92,7 +92,10 @@ export const QueryEditor = ({
     setIsSaved(false);
   };
 
-  const [queryParams, setQueryParams] = useState<KeyedParams>({});
+
+  const [userQueryParameters, setUserQueryParameters] = useLocalStorage('/query_parameters');
+
+  const [queryParams, setQueryParams] = useState<KeyedParams>(userQueryParameters ?? {});
   const onUpdateQueryParams = (key: string, value: string) => {
     const patch = { [key]: value };
     setQueryParams({ ...queryParams, ...patch });
@@ -118,25 +121,9 @@ export const QueryEditor = ({
     setIsSaved(true);
   };
 
-  const [userQueryParameters, setUserQueryParameters] = useLocalStorage('/query_parameters');
-
   const allParamsSet = TeraUtils.extractParams(draft.query).every(param => {
-    let result = false;
-    if (param) {
-      // when queryParams has values, use queryParams for allParamsSet, if not check if userQueryParameters (local storage) has values
-      if (Object.keys(queryParams).length > 0){
-        if(userQueryParameters){
-          result = queryParams[param] !== undefined ?  true : userQueryParameters[param] !== (undefined && "");
-        }else{
-          result = queryParams[param] !== undefined; // This allows the user to set the param to an empty string if they edit the field then delete the value
-        }
-      }else{
-        result = (userQueryParameters ?? queryParams)[param] !== (undefined && "");
-      }
-    } else {
-      result =  false;
-    }
-    return result;
+    return queryParams[param] !== (undefined && "");
+    //if (param) {}
   });
 
   let testQueryButton = (
@@ -146,7 +133,7 @@ export const QueryEditor = ({
       isLoading={queryLoading}
       startIcon={<ZapIcon />}
       onClick={() => {
-        runQuery(draft.query, TeraUtils.keyedParamsAsTeraJson(Object.keys(queryParams).length == 0? (userQueryParameters ?? queryParams) : queryParams));
+        runQuery(draft.query, TeraUtils.keyedParamsAsTeraJson(queryParams));
       }}
     >
       {t('label.test-sql-query')}

--- a/frontend/packages/system/src/Queries/NotificationQueries/SidePanel.tsx
+++ b/frontend/packages/system/src/Queries/NotificationQueries/SidePanel.tsx
@@ -18,14 +18,11 @@ export const SidePanel = ({
   queryParams,
   onUpdateQueryParams,
   generatedQuery,
-  userQueryParameters,
   setUserQueryParameters,
 }: ParamsPanelProps) => {
   const t = useTranslation('system');
 
   const onSaveInLocalStorage = (queryParams: KeyedParams) => {    
-    // When param is not changed from userQueryParameters, want to save it from userQueryParameters, 
-    // whne param is changed, want to save it from queryParams
     setUserQueryParameters(queryParams);
   };
 
@@ -63,7 +60,7 @@ export const SidePanel = ({
                         backgroundColor: 'white',
                       },
                     }}
-                    value={(userQueryParameters?? queryParams)[param ?? '']}
+                    value={queryParams[param ?? '']}
                     onChange={e =>
                       onUpdateQueryParams(param ?? '', e.target.value)
                     }

--- a/frontend/packages/system/src/Queries/NotificationQueries/SidePanel.tsx
+++ b/frontend/packages/system/src/Queries/NotificationQueries/SidePanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { BufferedTextArea } from '@notify-frontend/common';
-import { Box, DetailPanelPortal, PanelLabel, PanelRow } from '@common/ui';
-import { BufferedTextInput, DetailPanelSection } from '@common/components';
+import { BufferedTextArea} from '@notify-frontend/common';
+import { Box, DetailPanelPortal, PanelLabel, PanelRow, SaveIcon } from '@common/ui';
+import { BufferedTextInput, DetailPanelSection, IconButton } from '@common/components';
 import { KeyedParams, TeraUtils } from '@common/utils';
 import { useTranslation } from '@common/intl';
 
@@ -10,18 +10,38 @@ export interface ParamsPanelProps {
   queryParams: KeyedParams;
   onUpdateQueryParams: (key: string, value: string) => void;
   generatedQuery: string;
+  userQueryParameters: KeyedParams | null;
+  setUserQueryParameters: (queryParams: KeyedParams) => void;
 }
-
 export const SidePanel = ({
   query,
   queryParams,
   onUpdateQueryParams,
   generatedQuery,
+  userQueryParameters,
+  setUserQueryParameters,
 }: ParamsPanelProps) => {
   const t = useTranslation('system');
 
+  const onSaveInLocalStorage = (queryParams: KeyedParams) => {    
+    // When param is not changed from userQueryParameters, want to save it from userQueryParameters, 
+    // whne param is changed, want to save it from queryParams
+    setUserQueryParameters(queryParams);
+  };
+
   const paramEditor = (
-    <DetailPanelSection title={t('label.parameters')}>
+    <DetailPanelSection 
+      title={t('label.parameters')}
+      actionButtons={
+        <>
+          <IconButton
+            onClick={() => onSaveInLocalStorage(queryParams)}
+            icon={<SaveIcon />}
+            label={t('label.parameters-save-local')}
+          />
+        </>
+      }  
+    >
       {TeraUtils.extractParams(query).length === 0 ? (
         <PanelRow>
           <PanelLabel>{t('message.no-parameters')}</PanelLabel>
@@ -30,6 +50,7 @@ export const SidePanel = ({
         <>
           {TeraUtils.extractParams(query).map(param => {
             return (
+              
               <Box key={`param-${param}`} paddingBottom={2}>
                 <PanelRow>
                   <PanelLabel>{param}</PanelLabel>
@@ -42,7 +63,7 @@ export const SidePanel = ({
                         backgroundColor: 'white',
                       },
                     }}
-                    value={queryParams[param ?? '']}
+                    value={(userQueryParameters?? queryParams)[param ?? '']}
                     onChange={e =>
                       onUpdateQueryParams(param ?? '', e.target.value)
                     }
@@ -67,6 +88,5 @@ export const SidePanel = ({
         />
     </DetailPanelSection>
   );
-
   return <DetailPanelPortal>{paramEditor}{generatedSQLViewer}</DetailPanelPortal>;
 };

--- a/frontend/packages/system/src/Recipients/SqlRecipientLists/RecipientQueryEditor.tsx
+++ b/frontend/packages/system/src/Recipients/SqlRecipientLists/RecipientQueryEditor.tsx
@@ -17,6 +17,7 @@ import {
   useNotification,
   useToggle,
   useTranslation,
+  useLocalStorage,
 } from '@notify-frontend/common';
 import { DraftSqlRecipientList } from './types';
 import { useCreateSqlRecipientList, useUpdateSqlRecipientList } from '../api';
@@ -105,9 +106,12 @@ export const RecipientQueryEditor = ({
     setIsSaved(true);
   };
 
+  const [userQueryParameters, setUserQueryParameters] = useLocalStorage('/query_parameters');
+
   const allParamsSet = TeraUtils.extractParams(draft.query).every(param => {
     if (param) {
-      return queryParams[param] !== undefined; // This allows the user to set the param to an empty string if they edit the field then delete the value
+      // This allows the user to set the param to an empty string if they edit the field then delete the value
+      return (Object.keys(queryParams).length > 0)? queryParams[param] !== undefined : (userQueryParameters ?? queryParams)[param] !== (undefined || '');
     } else {
       return false;
     }
@@ -122,7 +126,7 @@ export const RecipientQueryEditor = ({
       onClick={() => {
         queryRecipients(
           draft.query,
-          TeraUtils.keyedParamsAsTeraJson(queryParams)
+          TeraUtils.keyedParamsAsTeraJson(Object.keys(queryParams).length == 0? (userQueryParameters ?? queryParams) : queryParams)
         );
       }}
     >
@@ -149,6 +153,8 @@ export const RecipientQueryEditor = ({
         query={draft.query}
         queryParams={queryParams}
         onUpdateQueryParams={onUpdateQueryParams}
+        userQueryParameters={userQueryParameters}
+        setUserQueryParameters={setUserQueryParameters}
       />
       <Grid flexDirection="column" display="flex" gap={1}>
         {isEditingName ? (

--- a/frontend/packages/system/src/Recipients/SqlRecipientLists/SidePanel.tsx
+++ b/frontend/packages/system/src/Recipients/SqlRecipientLists/SidePanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Box, DetailPanelPortal, PanelLabel, PanelRow } from '@common/ui';
-import { BufferedTextInput, DetailPanelSection } from '@common/components';
+import { Box, DetailPanelPortal, PanelLabel, PanelRow, SaveIcon } from '@common/ui';
+import { BufferedTextInput, DetailPanelSection, IconButton } from '@common/components';
 import { KeyedParams, TeraUtils } from '@common/utils';
 import { useTranslation } from '@common/intl';
 
@@ -8,17 +8,35 @@ export interface ParamsPanelProps {
   query: string;
   queryParams: KeyedParams;
   onUpdateQueryParams: (key: string, value: string) => void;
+  userQueryParameters: KeyedParams | null;
+  setUserQueryParameters: (queryParams: KeyedParams) => void;
 }
 
 export const SidePanel = ({
   query,
   queryParams,
   onUpdateQueryParams,
+  userQueryParameters,
+  setUserQueryParameters
 }: ParamsPanelProps) => {
   const t = useTranslation('system');
+  const onSaveInLocalStorage = (queryParams: KeyedParams) => {
+    setUserQueryParameters(queryParams);
+  };
 
   const paramEditor = (
-    <DetailPanelSection title={t('label.parameters')}>
+    <DetailPanelSection 
+      title={t('label.parameters')}
+      actionButtons={
+        <>
+          <IconButton
+            onClick={() => onSaveInLocalStorage(queryParams)}
+            icon={<SaveIcon />}
+            label={t('label.parameters-save-local')}
+          />
+        </>
+      }
+    >
       {TeraUtils.extractParams(query).length === 0 ? (
         <PanelRow>
           <PanelLabel>{t('message.no-parameters')}</PanelLabel>
@@ -39,7 +57,7 @@ export const SidePanel = ({
                         backgroundColor: 'white',
                       },
                     }}
-                    value={queryParams[param ?? '']}
+                    value={(userQueryParameters?? queryParams)[param ?? '']}
                     onChange={e =>
                       onUpdateQueryParams(param ?? '', e.target.value)
                     }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #229

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
- Added the function to save parameters in the local storage in Queries and SQL Recipients

# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

When all parameters(e.g. param1, param2) are already saved in the local storage, and user changes param1 and save it again, param1 should come from the user input, and param2 should come from the local storage. 
But I could not manage it...


## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Functional change 1
- [ ] Functional change 2
