### PR TITLE
262 show parsing/processing errors in event log

### DIFF
--- a/backend/service/src/notification/enqueue.rs
+++ b/backend/service/src/notification/enqueue.rs
@@ -175,7 +175,7 @@ fn create_failed_event_row(
         .map_err(|e| NotificationServiceError::DatabaseError(e))
     {
         Ok(()) => NotificationServiceError::InternalError(format!(
-            "Failed to add template to tera instance: {:?}",
+            "Failed to create notification: {:?}",
             e
         )),
         Err(db_err) => db_err,

--- a/backend/service/src/notification/enqueue.rs
+++ b/backend/service/src/notification/enqueue.rs
@@ -333,7 +333,7 @@ mod test {
         let notification_event_rows = notification_event_row_repository.un_sent().unwrap();
 
         assert_eq!(notification_event_rows.len(), 1);
-        assert_eq!(notification_event_rows[0].to_address, "-".to_string());
+        assert_eq!(notification_event_rows[0].to_address, "".to_string());
         assert_eq!(
             notification_event_rows[0].notification_type,
             NotificationType::Unknown


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Part of #262

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

If there is an internal error during the processing of a notification event, create a phantom failed notification event with no recipient, so can see it in the notification event log.

<img width="1551" alt="Screenshot 2023-11-24 at 11 54 28 AM" src="https://github.com/msupply-foundation/notify/assets/55115239/61f34411-f1fd-4ea5-bd51-4bfdccfeb8ff">
<img width="1170" alt="Screenshot 2023-11-24 at 11 53 51 AM" src="https://github.com/msupply-foundation/notify/assets/55115239/484f0c2a-fb06-44fc-91db-7aaec53f4533">



# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Create and run a scheduled event with a broken body template. Go to the events page and see an empty failed event with the parsing error details.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

- Seems a shame not to include the title if possible, but that may be the thing that failed to parse... probably possible but would cost more time
- The map_err is both a bit repetitive and I think not great that it has the side effect creating the event, but moving the adding of templates to tera to a separate `try_add_templates_to_tera` method involved a lot of passing things around e.g. the tera instance - but I'm not very confident in my Rust yet so maybe I'm just missing the way to do it!




