### PR TITLE
260 pagination fix

### DIFF
--- a/frontend/packages/common/src/ui/layout/tables/types.ts
+++ b/frontend/packages/common/src/ui/layout/tables/types.ts
@@ -25,7 +25,7 @@ export interface TableProps<T extends RecordWithId> {
   isLoading?: boolean;
   noDataMessage?: string;
   noDataElement?: JSX.Element;
-  pagination?: Pagination & { total?: number };
+  pagination?: Pagination & { total: number | undefined };
   onChangePage?: (page: number) => void;
   onRowClick?: null | ((row: T) => void);
 }

--- a/frontend/packages/system/src/NotificationEvents/ListView/ListView.tsx
+++ b/frontend/packages/system/src/NotificationEvents/ListView/ListView.tsx
@@ -93,6 +93,7 @@ export const ListView = ({}: ListViewProps) => {
     page: queryParams.page,
     offset: queryParams.offset,
     first: queryParams.first,
+    total: data?.totalCount,
   };
 
   return (

--- a/frontend/packages/system/src/Notifications/ListView/ListView.tsx
+++ b/frontend/packages/system/src/Notifications/ListView/ListView.tsx
@@ -86,6 +86,7 @@ export const ListView = ({ kind }: ListViewProps) => {
     page: queryParams.page,
     offset: queryParams.offset,
     first: queryParams.first,
+    total: data?.totalCount,
   };
 
   return (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #260

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Fixes missing pagination controls on Notifications and Events pages. It wasn't rendering as the total count wasn't being provided.

Updated the DataTable pagination input type to require `total`.

# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Pagination controls should be available on both pages (and all others)

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

