### PR TITLE
fix search bar clearance race condition

### DIFF
--- a/frontend/packages/common/src/ui/components/inputs/SearchBar/SearchBar.tsx
+++ b/frontend/packages/common/src/ui/components/inputs/SearchBar/SearchBar.tsx
@@ -48,19 +48,6 @@ export const SearchBar: FC<SearchBarProps> = ({
 
   const isClearable = !(isLoading || loading) && buffer.length > 0;
 
-  const clearInputButton = (
-    <IconButton
-      sx={{ color: 'gray.main' }}
-      onClick={() => {
-        setBuffer('');
-        debouncedOnChange('');
-        setLoading(true);
-      }}
-      icon={<CloseIcon fontSize="small" />}
-      label={t('label.clear-search')}
-    />
-  );
-
   return (
     <>
       <BasicTextInput
@@ -69,7 +56,22 @@ export const SearchBar: FC<SearchBarProps> = ({
             <SearchIcon sx={{ color: 'gray.main' }} fontSize="small" />
           ),
           endAdornment: isClearable ? (
-            <InputAdornment position="end">{clearInputButton}</InputAdornment>
+            <InputAdornment
+              position="end"
+              onMouseDown={() => {
+                setBuffer('');
+                debouncedOnChange('');
+                setLoading(true);
+              }}
+            >
+              <IconButton
+                sx={{ color: 'gray.main' }}
+                icon={<CloseIcon fontSize="small" />}
+                label={t('label.clear-search')}
+                // onClick handled by above `onMouseDown` to prevent race condition with focus shifting away from the input!
+                onClick={() => {}}
+              />
+            </InputAdornment>
           ) : (
             <Spin isLoading={isLoading || loading} />
           ),


### PR DESCRIPTION
[As found in Universal Codes](https://github.com/msupply-foundation/unified-codes/pull/434#discussion_r1423310098)

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

There was some kind of race condition going on with the clear search `X` button. Sometimes the `onClick` would fire and clear the search, but sometimes the focus would shift away from the input first, so the search field would shrink without clearing.

This PR updates the clear logic to run on `onMouseDown`, which fires before the focus change, so the search will reliably clear!

# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Type in a search field and clear it lots of times 😅 

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->


