### PR TITLE
283 mask outlier temperature spikes

### DIFF
--- a/backend/coldchain/src/latest_temperature.rs
+++ b/backend/coldchain/src/latest_temperature.rs
@@ -29,6 +29,7 @@ pub fn latest_temperature(
     temperature
     FROM temperature_log
     WHERE sensor_id = $1
+    AND temperature < 55 -- ignore any obviously bad data see: https://github.com/msupply-foundation/notify/issues/283
     ORDER BY date DESC, time DESC
     LIMIT 1";
 

--- a/backend/repository/src/tests.rs
+++ b/backend/repository/src/tests.rs
@@ -80,6 +80,9 @@ mod repository_test {
         let (_, connection, _, _) =
             test_db::setup_all("test_backup", MockDataInserts::none()).await;
 
+        // cleanup
+        std::fs::remove_file("test_backup.sqlite").unwrap();
+
         let result = backup_sqlite(&connection, "test_backup.sqlite");
 
         assert_eq!(result, Ok(()));


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #283

# 👩🏻‍💻 What does this PR do?
Ignores datapoints with temperature over 55 degrees, these are very likely to be not correct in cold chain installations.

# 🧪 How has/should this change been tested?
not much testing done yet, we'll leave this to QA to verify.

## 💌 Any notes for the reviewer?
