### PR TITLE
Improve logging, and skip parameter sets with not recipients

### DIFF
--- a/backend/scheduled/src/query.rs
+++ b/backend/scheduled/src/query.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use log::info;
 use repository::{EqualFilter, NotificationQueryFilter, NotificationQueryRepository};
 use serde_json::json;
 use service::service_provider::ServiceContext;
@@ -27,6 +28,7 @@ pub fn get_notification_query_results(
 
     // loop through all the notification query ids, run them, and store the results
     for query in queries {
+        let now = chrono::Utc::now();
         let result = ctx
             .service_provider
             .datasource_service
@@ -45,6 +47,13 @@ pub fn get_notification_query_results(
                 json!([{"error": "error running query", "query": query.query, "parameters": parameters}])
             }
         };
+        let end_time = chrono::Utc::now();
+        info!(
+            "Query {} took {}ms",
+            query.reference_name,
+            (end_time - now).num_milliseconds()
+        );
+
         query_results.insert(query.reference_name, query_json);
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #286

# 👩🏻‍💻 What does this PR do?

Adds some additional logging and timing information to scheduled reports

Also skips any parameter sets with no reciepients (saving time if there's a lot of parameter sets with not recipients)
```
2024-02-12 12:27:44.703764000 [INFO] <scheduled::process:145>:Processing parameter set: {"project":"MOVEX","province":"NOT A PROVINCE"}
2024-02-12 12:27:44.714748000 [INFO] <scheduled::process:159>:No notification targets, skipping
2024-02-12 12:27:44.714942000 [INFO] <scheduled::process:51>:Successfully created notification events
```
# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

A little bit of testing locally, there's not new tests cases added.

## 💌 Any notes for the reviewer?
There's a slight change in behaviour here, as it used to be that sql recipients could use parameters from SQL Queries run. I think this logic is easier and clearer though.

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_
