### PR TITLE
300 required querys

### DIFF
--- a/backend/repository/src/db_diesel/notification_event_row.rs
+++ b/backend/repository/src/db_diesel/notification_event_row.rs
@@ -109,9 +109,21 @@ impl<'a> NotificationEventRowRepository<'a> {
             .filter(
                 notification_event_dsl::status
                     .eq(NotificationEventStatus::Queued)
-                    .or(notification_event_dsl::status.eq(NotificationEventStatus::Errored)
+                    .or(notification_event_dsl::status
+                        .eq(NotificationEventStatus::Errored)
                         .and(notification_event_dsl::retry_at.le(diesel::dsl::now))),
             )
+            .load::<NotificationEventRow>(&self.connection.connection)?;
+        Ok(result)
+    }
+
+    // Used for tests only
+    pub fn errors(&self) -> Result<Vec<NotificationEventRow>, RepositoryError> {
+        let result = notification_event_dsl::notification_event
+            .filter(notification_event_dsl::status.eq_any(vec![
+                NotificationEventStatus::Failed,
+                NotificationEventStatus::Errored,
+            ]))
             .load::<NotificationEventRow>(&self.connection.connection)?;
         Ok(result)
     }

--- a/backend/repository/src/mock/notification_query.rs
+++ b/backend/repository/src/mock/notification_query.rs
@@ -4,6 +4,7 @@ pub fn mock_notification_queries() -> Vec<NotificationQueryRow> {
     vec![
         mock_notification_query_with_params(),
         mock_notification_query_with_no_param_2_rows(),
+        mock_notification_query_with_no_rows(),
     ]
 }
 
@@ -32,6 +33,19 @@ SELECT 1.51 as latest_temperature, 'sensor2' as sensor_name, -10 as sensor_limit
         query: sql_query.to_string(),
         required_parameters: "[]".to_string(),
         reference_name: String::from("query2"),
+        ..Default::default()
+    }
+}
+
+pub fn mock_notification_query_with_no_rows() -> NotificationQueryRow {
+    let sql_query = r#"SELECT 1 as value WHERE 1 = 0"#;
+    NotificationQueryRow {
+        id: String::from("id_notification_query_no_rows"),
+        name: String::from("notification_query_no_rows"),
+        description: String::from("Returns no rows - for testing required query behavior"),
+        query: sql_query.to_string(),
+        required_parameters: "[]".to_string(),
+        reference_name: String::from("query_no_rows"),
         ..Default::default()
     }
 }

--- a/backend/scheduled/src/parse.rs
+++ b/backend/scheduled/src/parse.rs
@@ -14,6 +14,9 @@ use crate::NotificationError;
         "98533e08-99bb-4b18-a045-db67e1852d73",
         "aca03f15-96a1-4f36-bd80-1fd34331a5f1"
     ],
+    "requiredQueryIds": [
+        "72e5342f-08b7-499b-8a51-339ae142f68a"
+    ],
     "parameters": "{\"email_address\":\"test@example.com\",\"project\":\"prj1\",\"province\":\"prov1\"}",
     "parsedParameters": {
         "email_address": "test@example.com",
@@ -49,6 +52,8 @@ pub struct ScheduledNotificationPluginConfig {
     pub schedule_start_time: DateTime<Utc>,
     #[serde(default)]
     pub notification_query_ids: Vec<String>,
+    #[serde(default)]
+    pub required_query_ids: Vec<String>,
 }
 
 impl ScheduledNotificationPluginConfig {

--- a/backend/scheduled/src/query.rs
+++ b/backend/scheduled/src/query.rs
@@ -55,13 +55,23 @@ pub fn get_notification_query_results(
         };
 
         // If the query is required and there are no results, return an error
-        if required_query_ids.contains(&query.id)
-            && (query_json.as_array().map_or(true, |arr| arr.is_empty()))
-        {
-            return Ok(NotificationQueryResult::Skipped(format!(
-                "Required query {} returned no results",
-                query.reference_name
-            )));
+        if required_query_ids.contains(&query.id) {
+            match query_json.as_array() {
+                Some(arr) if arr.is_empty() => {
+                    return Ok(NotificationQueryResult::Skipped(format!(
+                        "Required query {} returned no results",
+                        query.reference_name
+                    )));
+                }
+                None => {
+                    return Err(NotificationError::InternalError(format!(
+                        "Required query {} did not return an array (got: {})",
+                        query.reference_name,
+                        query_json
+                    )));
+                }
+                _ => {}
+            }
         }
 
         let end_time = chrono::Utc::now();

--- a/backend/service/src/notification/enqueue.rs
+++ b/backend/service/src/notification/enqueue.rs
@@ -330,7 +330,7 @@ mod test {
 
         // Check we have a notification event with error message
         let notification_event_row_repository = NotificationEventRowRepository::new(&connection);
-        let notification_event_rows = notification_event_row_repository.un_sent().unwrap();
+        let notification_event_rows = notification_event_row_repository.errors().unwrap();
 
         assert_eq!(notification_event_rows.len(), 1);
         assert_eq!(notification_event_rows[0].to_address, "".to_string());

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notify-frontend",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "sideEffects": false,
   "private": true,
   "scripts": {

--- a/frontend/packages/common/src/intl/locales/en/common.json
+++ b/frontend/packages/common/src/intl/locales/en/common.json
@@ -197,5 +197,6 @@
   "label.body-template": "Body template",
   "label.parameters": "Parameters",
   "label.reference-name": "Reference Name",
-  "label.notification-type": "Notification Type"
+  "label.notification-type": "Notification Type",
+  "label.required": "Required"
 }

--- a/frontend/packages/system/src/Notifications/Pages/Scheduled/ScheduledNotificationEditForm.tsx
+++ b/frontend/packages/system/src/Notifications/Pages/Scheduled/ScheduledNotificationEditForm.tsx
@@ -119,6 +119,11 @@ export const ScheduledNotificationEditForm = ({
           setSelection={props => {
             onUpdate(props as Partial<ScheduledNotification>);
           }}
+          requiredQueryIds={draft.requiredQueryIds}
+          setRequiredQueryIds={ids => {
+            const patch = { ...draft, requiredQueryIds: ids };
+            onUpdate(patch as Partial<ScheduledNotification>);
+          }}
         />
       </Box>
       <FormRow title={t('label.schedule')}>

--- a/frontend/packages/system/src/Notifications/Pages/Scheduled/parseConfig.ts
+++ b/frontend/packages/system/src/Notifications/Pages/Scheduled/parseConfig.ts
@@ -53,6 +53,7 @@ export const defaultSchedulerNotification: ScheduledNotification = {
   subjectTemplate: '',
   bodyTemplate: '',
   notificationQueryIds: [],
+  requiredQueryIds: [],
   status: ConfigStatus.Disabled,
 };
 

--- a/frontend/packages/system/src/Notifications/components/SqlQuerySelector.tsx
+++ b/frontend/packages/system/src/Notifications/components/SqlQuerySelector.tsx
@@ -17,24 +17,42 @@ import { NotificationQueryRowFragment } from '../../Queries/api';
 type QueryListProps = {
   allQueries: NotificationQueryRowFragment[];
   selectedQueryIds: string[];
+  requiredQueryIds: string[];
   setSelection: (input: {
     notificationQueryIds: string[];
     requiredParameters: string[];
   }) => void;
+  setRequiredQueryIds: (ids: string[]) => void;
   isLoading: boolean;
 };
 
 export const SqlQuerySelector: FC<QueryListProps> = ({
   allQueries,
   selectedQueryIds,
+  requiredQueryIds,
   setSelection,
+  setRequiredQueryIds,
   isLoading,
 }) => {
   const t = useTranslation('system');
 
   const { isOpen, onClose, onOpen } = useEditModal();
 
-  const columns = useColumns<NotificationQueryRowFragment>([
+  const onSetRequired = (id: string, required: boolean) => {
+    let newRequiredIds = [...requiredQueryIds];
+    if (required) {
+      if (!newRequiredIds.includes(id)) {
+        newRequiredIds.push(id);
+      }
+    } else {
+      newRequiredIds = newRequiredIds.filter(rid => rid !== id);
+    }
+    setRequiredQueryIds(newRequiredIds);
+  };
+
+  const columns = useColumns<
+    NotificationQueryRowFragment & { required: boolean }
+  >([
     {
       key: 'referenceName',
       label: 'label.reference-name',
@@ -52,7 +70,7 @@ export const SqlQuerySelector: FC<QueryListProps> = ({
       label: 'label.query',
       width: 150,
       sortable: false,
-      accessor: ({ rowData }) => StringUtils.ellipsis(rowData?.query, 100),
+      accessor: ({ rowData }) => StringUtils.ellipsis(rowData?.query, 50),
     },
     {
       key: 'requiredParameters',
@@ -60,11 +78,27 @@ export const SqlQuerySelector: FC<QueryListProps> = ({
       sortable: false,
       accessor: ({ rowData }) => rowData?.requiredParameters.join(', '),
     },
+    {
+      key: 'required',
+      label: 'label.required',
+      width: 100,
+      sortable: false,
+      Cell: ({ rowData }) => (
+        <input
+          type="checkbox"
+          checked={rowData?.required || false}
+          onChange={e => onSetRequired(rowData.id, e.target.checked)}
+        />
+      ),
+    },
   ]);
 
-  const selectedQueries = (allQueries ?? []).filter(q =>
-    selectedQueryIds.includes(q.id)
-  );
+  const selectedQueries = (allQueries ?? [])
+    .filter(q => selectedQueryIds.includes(q.id))
+    .map(q => ({
+      ...q,
+      required: requiredQueryIds?.includes(q.id) ?? false,
+    }));
 
   return (
     <>

--- a/frontend/packages/system/src/Notifications/types.ts
+++ b/frontend/packages/system/src/Notifications/types.ts
@@ -75,4 +75,5 @@ export interface ScheduledNotification extends BaseNotificationConfig {
   subjectTemplate: string;
   bodyTemplate: string;
   notificationQueryIds: string[];
+  requiredQueryIds: string[];
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #300

# 👩🏻‍💻 What does this PR do?
Makes it possible to mark a query as required.
If a query is required scheduled notifications won't run when there's no data returned for that query.

# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

## 💌 Any notes for the reviewer?

I think there's some kind of bug where the notification config gets over-written when clicking required.
I saw it happen twice but can't replicate now.

## 📃 Documentation
<!-- Note down any areas which require documentation updates -->
_No user facing changes_

or

- [ ] Required Query Functionality...
